### PR TITLE
podman: add docker.io to fix podman issues on ubuntu 25.04

### DIFF
--- a/podman-compose-headless.yml
+++ b/podman-compose-headless.yml
@@ -6,7 +6,7 @@ volumes:
   cache:
 services:
   elements:
-    image: dnltz/elements:v1.2
+    image: docker.io/dnltz/elements:v1.2
     container_name: elemrv_container
     environment:
       - DISPLAY=${DISPLAY}

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -6,7 +6,7 @@ volumes:
   cache:
 services:
   elements:
-    image: dnltz/elements:v1.2
+    image: docker.io/dnltz/elements:v1.2
     container_name: elemrv_container
     environment:
       - DISPLAY=${DISPLAY}


### PR DESCRIPTION
Gets further:

```
$ git log -1
commit d363e82d1f6e561f7b01bd0ff7d0cfb19703396e (HEAD -> main, oharboe/podman-fix)
Author: Øyvind Harboe <oyvind.harboe@zylin.com>
Date:   Sat Jun 7 10:24:03 2025 +0200

    podman: add docker.io to fix podman issues on ubuntu 25.04
    
    Signed-off-by: Øyvind Harboe <oyvind.harboe@zylin.com>
$ task prepare layout filler
[deleted]
[NesterovSolve] Iter:  400 overflow: 0.342 HPWL: 3756650773
[NesterovSolve] Iter:  410 overflow: 0.312 HPWL: 3763011718
[INFO GPL-0075] Routability iteration: 1
[ERROR GRT-0042] Pin io_forFutureUse_0_PAD does not have geometries in a valid routing layer.
Error: global_place.tcl, 38 GRT-0042
Command exited with non-zero status 1
Elapsed time: 1:27.59[h:]min:sec. CPU time: user 376.21 sys 1.03 (430%). Peak memory: 1268356KB.
make[1]: *** [Makefile:641: do-3_3_place_gp] Error 1
make: *** [Makefile:639: /home/oyvind/ElemRV/build//ElemRV/SG13G2/orfs//results/ihp-sg13g2/SG13G2Top/base/3_3_place_gp.odb] Error 2
make: Leaving directory '/home/oyvind/ElemRV/tools/OpenROAD-flow-scripts/flow'
task: Failed to run task "layout": exit status 2
```
