### PR TITLE
SPI: Quad I/O

### DIFF
--- a/hardware/scala/elemrv_n/ECPIX5/ECPIX5.scala
+++ b/hardware/scala/elemrv_n/ECPIX5/ECPIX5.scala
@@ -40,8 +40,7 @@ case class ECPIX5Board() extends Component {
     val spi = new Bundle {
       val cs = inout(Analog(Bool))
       val sck = inout(Analog(Bool))
-      val mosi = inout(Analog(Bool))
-      val miso = inout(Analog(Bool))
+      val dq = Vec(inout(Analog(Bool)), 4)
     }
     val pins = Vec(inout(Analog(Bool())), 20)
   }
@@ -83,20 +82,18 @@ case class ECPIX5Board() extends Component {
     io.hyperbus.dq(index) <> top.io.hyperbus.dq(index).PAD
   }
 
-  val spiNor = MT25Q()
+  val spiNor = MT25Q.MultiProtocol()
   spiNor.io.clock := io.clock
   spiNor.io.dataClock := io.spi.sck
   spiNor.io.reset := io.reset
   spiNor.io.chipSelect := io.spi.cs
-  spiNor.io.dataIn := io.spi.mosi
-  top.io.spi.dq(1).PAD := spiNor.io.dataOut
-
   io.spi.cs := top.io.spi.cs(0).PAD
   io.spi.sck := top.io.spi.sck.PAD
-  io.spi.mosi := top.io.spi.dq(0).PAD
-  top.io.spi.dq(1).PAD := io.spi.miso
-  top.io.spi.dq(2).PAD := analogFalse
-  top.io.spi.dq(3).PAD := analogFalse
+  for (index <- 0 until top.io.spi.dq.length) {
+    spiNor.io.dqIn(index) := io.spi.dq(index)
+    io.spi.dq(index) := top.io.spi.dq(index).PAD
+    top.io.spi.dq(index).PAD := spiNor.io.dqOut(index)
+  }
 
   for (index <- 0 until top.io.pins.length) {
     io.pins(index) <> top.io.pins(index).PAD

--- a/manifest-nightly.xml
+++ b/manifest-nightly.xml
@@ -11,8 +11,8 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 
 	<default remote="github" sync-j="8" />
 
-	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="7e2a5768636d9658ca9f144db1b71b6a225b54bc" />
-	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="4d38f69932531b034feb6b9d12aae390fb24b24e" />
+	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="299b23796c5f4afe95f99c5318b8c4c010b6a488" />
+	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="de7b8ec1159df09d27663f22a37082b9df76bd2f" />
 	<project name="SpinalHDL/SpinalCrypto" path="modules/elements/SpinalCrypto" revision="f2a4ae9db5e9434c5589d0651efec8719103498e" />
 	<project name="aesc-silicon/elements-vexriscv" path="modules/elements/vexriscv" revision="7f2bccbef256b3ad40fb8dc8ba08a266f9c6256b" />
 	<project name="aesc-silicon/gdsiistl" path="tools/gdsiistl" revision="5884b20565a765f10918eedc0787a2beb6a682fd" />

--- a/manifest.xml
+++ b/manifest.xml
@@ -11,8 +11,8 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 
 	<default remote="github" sync-j="8" />
 
-	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="7e2a5768636d9658ca9f144db1b71b6a225b54bc" />
-	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="4d38f69932531b034feb6b9d12aae390fb24b24e" />
+	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="299b23796c5f4afe95f99c5318b8c4c010b6a488" />
+	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="de7b8ec1159df09d27663f22a37082b9df76bd2f" />
 	<project name="SpinalHDL/SpinalCrypto" path="modules/elements/SpinalCrypto" revision="f2a4ae9db5e9434c5589d0651efec8719103498e" />
 	<project name="aesc-silicon/elements-vexriscv" path="modules/elements/vexriscv" revision="7f2bccbef256b3ad40fb8dc8ba08a266f9c6256b" />
 	<project name="aesc-silicon/gdsiistl" path="tools/gdsiistl" revision="5884b20565a765f10918eedc0787a2beb6a682fd" />

--- a/software/elemrv_h/demo/start.s
+++ b/software/elemrv_h/demo/start.s
@@ -13,6 +13,7 @@ _head:
 	li	a0, 1
 	jal	gpio_set_pin
 
+	jal	_init_xip
 	jal	_init_regs
 	jal	_init_bss
 
@@ -56,7 +57,12 @@ _init_regs:
 	li	x31, 0xD1D1D1D1
 	ret
 
-
+_init_xip:
+	li	t0, 0xf0025000
+	li	t1, 0x007f0702
+	sw	t1, 0xc(t0)
+	sw	t1, 0x8(t0)
+	ret
 
 _init_bss:
 	la	t0, __bss_start
@@ -70,7 +76,6 @@ loop_head:
 loop_end:
 	ret
 	nop
-
 
 timer_enable:
 	csrr	a0, mie

--- a/software/elemrv_n/bootrom/start.s
+++ b/software/elemrv_n/bootrom/start.s
@@ -12,8 +12,9 @@ _head:
 	li	a0, 1
 	jal	gpio_set_pin
 
-	jal	_init_regs
+	jal	_init_xip
 	#jal	_init_memc
+	jal	_init_regs
 	jal	_init_bss
 
 	li	a0, 0
@@ -67,6 +68,13 @@ _init_memc:
 	sw	t1, 0x20(t0) # latency cycles
 	li	t1, 1
 	sw	t1, 0x10(t0) # reset chip
+	ret
+
+_init_xip:
+	li	t0, 0xf0025000
+	li	t1, 0x007f0702
+	sw	t1, 0xc(t0)
+	sw	t1, 0x8(t0)
 	ret
 
 _init_bss:


### PR DESCRIPTION
Re-configure the SPI XIP interface as early as possible and switch to the Quad I/O protocol to increase the bandwidth.