### PR TITLE
Improve ElemRV-H Performance

### DIFF
--- a/hardware/scala/elemrv_h/ECPIX5/ECPIX5.scala
+++ b/hardware/scala/elemrv_h/ECPIX5/ECPIX5.scala
@@ -63,6 +63,7 @@ case class ECPIX5Board() extends Component {
     io.spi.dq(index) := top.io.spi.dq(index).PAD
     top.io.spi.dq(index).PAD := spiNor.io.dqOut(index)
   }
+  top.io.spi.rst.PAD := analogFalse
 
   for (index <- 0 until top.io.pins.length) {
     io.pins(index) <> top.io.pins(index).PAD

--- a/hardware/scala/elemrv_h/ECPIX5/ECPIX5.scala
+++ b/hardware/scala/elemrv_h/ECPIX5/ECPIX5.scala
@@ -105,10 +105,7 @@ case class ECPIX5Top() extends Component {
         clock,
         resetCtrl,
         boardParameter.getOscillatorFrequency,
-        List("system", "debug"),
-        2,
-        1,
-        10
+        List("system", "debug")
       )
     },
     (parameter: BmbParameter, ramSize: BigInt) => {

--- a/hardware/scala/elemrv_h/ECPIX5/ECPIX5.scala
+++ b/hardware/scala/elemrv_h/ECPIX5/ECPIX5.scala
@@ -89,7 +89,7 @@ case class ECPIX5Top() extends Component {
     ResetParameter("debug", 128)
   )
   val clocks = List[ClockParameter](
-    ClockParameter("system", 25 MHz, "system"),
+    ClockParameter("system", 50 MHz, "system"),
     ClockParameter("debug", 10 MHz, "debug", synchronousWith = "system")
   )
   val kitParameter = KitParameter(resets, clocks)

--- a/hardware/scala/elemrv_h/SG13G2/SG13G2.scala
+++ b/hardware/scala/elemrv_h/SG13G2/SG13G2.scala
@@ -84,7 +84,7 @@ case class SG13G2Top() extends Component {
     ResetParameter("debug", 128)
   )
   val clocks = List[ClockParameter](
-    ClockParameter("system", 25 MHz, "system"),
+    ClockParameter("system", 50 MHz, "system"),
     ClockParameter("debug", 10 MHz, "debug", synchronousWith = "system")
   )
   val kitParameter = KitParameter(resets, clocks)
@@ -181,8 +181,8 @@ object SG13G2Generate extends ElementsApp {
   }
 
   val chip = OpenROADTools.IHP.Config(elementsConfig, OpenROADTools.PDKs.IHP.sg13g2)
-  chip.dieArea = (0, 0, 2150.4, 2150.82)
-  chip.coreArea = (394.08, 396.9, 1753.44, 1753.92)
+  chip.dieArea = (0, 0, 1881.6, 1882.44)
+  chip.coreArea = (394.08, 396.9, 1484.64, 1485.54)
   chip.hasIoRing = true
   chip.addMacro(
     report.toplevel.soc.system.onChipRam.ctrl.asInstanceOf[BmbIhpOnChipRam.OnePort1Macro].ram,
@@ -191,7 +191,7 @@ object SG13G2Generate extends ElementsApp {
     "MX"
   )
 
-  chip.addClock(report.toplevel.io.clock.PAD, 25 MHz, "clk_main")
+  chip.addClock(report.toplevel.io.clock.PAD, 50 MHz, "clk_main")
   chip.addClock(report.toplevel.io.jtag.tck.PAD, 10 MHz, "clk_jtag")
   chip.setFalsePath("clk_main", "clk_jtag")
   chip.io = Some(report.toplevel.io)
@@ -220,7 +220,7 @@ object SG13G2Simulate extends ElementsApp {
         val testCases = TestCases()
         testCases.addClock(
           dut.io.clock,
-          ElemRVBoard.SystemClock.frequency,
+          50 MHz, // TODO fix missing PLL
           simDuration.toString.toInt ms
         )
         testCases.addReset(dut.io.reset, 100 us)

--- a/hardware/scala/elemrv_n/ECPIX5/ECPIX5.scala
+++ b/hardware/scala/elemrv_n/ECPIX5/ECPIX5.scala
@@ -94,6 +94,7 @@ case class ECPIX5Board() extends Component {
     io.spi.dq(index) := top.io.spi.dq(index).PAD
     top.io.spi.dq(index).PAD := spiNor.io.dqOut(index)
   }
+  top.io.spi.rst.PAD := analogFalse
 
   for (index <- 0 until top.io.pins.length) {
     io.pins(index) <> top.io.pins(index).PAD

--- a/hardware/scala/elemrv_n/ECPIX5/ECPIX5.scala
+++ b/hardware/scala/elemrv_n/ECPIX5/ECPIX5.scala
@@ -145,10 +145,7 @@ case class ECPIX5Top() extends Component {
         clock,
         resetCtrl,
         boardParameter.getOscillatorFrequency,
-        List("system", "cpu", "debug"),
-        2,
-        1,
-        8
+        List("system", "cpu", "debug")
       )
     },
     (parameter: BmbParameter, ramSize: BigInt) => {

--- a/manifest-nightly.xml
+++ b/manifest-nightly.xml
@@ -11,8 +11,8 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 
 	<default remote="github" sync-j="8" />
 
-	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="06e4cc7f398181161f6688fdba701d111b8bd21b" />
-	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="de7b8ec1159df09d27663f22a37082b9df76bd2f" />
+	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="ec37d766b941caa5699897a5dfc4ef08ac42744e" />
+	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="0c696a0de5192d87774df750838008bfedc181f8" />
 	<project name="SpinalHDL/SpinalCrypto" path="modules/elements/SpinalCrypto" revision="f2a4ae9db5e9434c5589d0651efec8719103498e" />
 	<project name="aesc-silicon/elements-vexriscv" path="modules/elements/vexriscv" revision="7f2bccbef256b3ad40fb8dc8ba08a266f9c6256b" />
 	<project name="aesc-silicon/gdsiistl" path="tools/gdsiistl" revision="5884b20565a765f10918eedc0787a2beb6a682fd" />

--- a/manifest-nightly.xml
+++ b/manifest-nightly.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="ec37d766b941caa5699897a5dfc4ef08ac42744e" />
 	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="0c696a0de5192d87774df750838008bfedc181f8" />
 	<project name="SpinalHDL/SpinalCrypto" path="modules/elements/SpinalCrypto" revision="f2a4ae9db5e9434c5589d0651efec8719103498e" />
-	<project name="aesc-silicon/elements-vexriscv" path="modules/elements/vexriscv" revision="7f2bccbef256b3ad40fb8dc8ba08a266f9c6256b" />
+	<project name="aesc-silicon/elements-vexriscv" path="modules/elements/vexriscv" revision="2130484fe93c04edc0f17a4991108fdef9db89b3" />
 	<project name="aesc-silicon/gdsiistl" path="tools/gdsiistl" revision="5884b20565a765f10918eedc0787a2beb6a682fd" />
 	<project name="The-OpenROAD-Project/OpenROAD-flow-scripts" path="tools/OpenROAD-flow-scripts" revision="master" />
 	<project name="IHP-GmbH/IHP-Open-PDK" sync-s="true" path="pdks/IHP-Open-PDK" revision="dev" />

--- a/manifest.xml
+++ b/manifest.xml
@@ -11,8 +11,8 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 
 	<default remote="github" sync-j="8" />
 
-	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="06e4cc7f398181161f6688fdba701d111b8bd21b" />
-	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="de7b8ec1159df09d27663f22a37082b9df76bd2f" />
+	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="ec37d766b941caa5699897a5dfc4ef08ac42744e" />
+	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="0c696a0de5192d87774df750838008bfedc181f8" />
 	<project name="SpinalHDL/SpinalCrypto" path="modules/elements/SpinalCrypto" revision="f2a4ae9db5e9434c5589d0651efec8719103498e" />
 	<project name="aesc-silicon/elements-vexriscv" path="modules/elements/vexriscv" revision="7f2bccbef256b3ad40fb8dc8ba08a266f9c6256b" />
 	<project name="aesc-silicon/gdsiistl" path="tools/gdsiistl" revision="5884b20565a765f10918eedc0787a2beb6a682fd" />

--- a/manifest.xml
+++ b/manifest.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="ec37d766b941caa5699897a5dfc4ef08ac42744e" />
 	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="0c696a0de5192d87774df750838008bfedc181f8" />
 	<project name="SpinalHDL/SpinalCrypto" path="modules/elements/SpinalCrypto" revision="f2a4ae9db5e9434c5589d0651efec8719103498e" />
-	<project name="aesc-silicon/elements-vexriscv" path="modules/elements/vexriscv" revision="7f2bccbef256b3ad40fb8dc8ba08a266f9c6256b" />
+	<project name="aesc-silicon/elements-vexriscv" path="modules/elements/vexriscv" revision="2130484fe93c04edc0f17a4991108fdef9db89b3" />
 	<project name="aesc-silicon/gdsiistl" path="tools/gdsiistl" revision="5884b20565a765f10918eedc0787a2beb6a682fd" />
 	<project name="The-OpenROAD-Project/OpenROAD-flow-scripts" path="tools/OpenROAD-flow-scripts" revision="a53c2e0d12c70105245f203d555f9628c71f245a" />
 	<project name="IHP-GmbH/IHP-Open-PDK" sync-s="true" path="pdks/IHP-Open-PDK" revision="5fb50772cfe7c957a49eadb80c25aae3def38fe0" />


### PR DESCRIPTION
- Update system clock from 25 to 50 MHz.
- Increase the SPI initial frequency from 1 to 5 MHz.
- Additionally, reduce the total chip size by 14 %.