### PR TITLE
Add ElemRV-N + GPIO + UART digital-twin co-simulation (first slice)

### DIFF
--- a/.github/workflows/digital-twin-tests.yaml
+++ b/.github/workflows/digital-twin-tests.yaml
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: 2025 aesc silicon
+#
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+
+# Digital Twin CI: builds Verilator co-simulation libraries for the
+# ElemRV-N + GPIO + UART slice, builds the Zephyr blinky app, and runs
+# the 5-test suite inside a simulation container.
+#
+# Until the upstream `elements-container` image ships Renode 1.16.0 and
+# Verilator (see
+# https://github.com/aesc-silicon/ElemRV/issues/13#issuecomment-4365667159),
+# this workflow expects a temporary `elemrv-sim` image. Override via the
+# `container_image` workflow_dispatch input.
+
+name: Digital Twin Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      container_image:
+        description: "Simulation container image (Renode 1.16.0 + Verilator + sbt + RISC-V toolchain + Zephyr SDK)"
+        required: false
+        default: "elemrv-sim:latest"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: ${{ github.event.inputs.container_image || 'elemrv-sim:latest' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Confirm simulation container image is present
+        run: |
+          if ! docker image inspect "${IMAGE}" >/dev/null 2>&1; then
+            echo "Container image '${IMAGE}' not available on this runner."
+            echo "Provide an image with Renode 1.16.0 + Verilator + sbt +"
+            echo "RISC-V toolchain + Zephyr SDK and pass it via the"
+            echo "'container_image' workflow_dispatch input. See"
+            echo "https://github.com/aesc-silicon/ElemRV/issues/13#issuecomment-4365667159"
+            exit 1
+          fi
+
+      - name: Start container
+        run: |
+          docker run -d --name elemrv-test \
+            -v ${{ github.workspace }}:/workspace/elemrv \
+            -w /workspace/elemrv \
+            "${IMAGE}" sleep infinity
+
+      - name: Configure git safe directories
+        run: docker exec elemrv-test git config --global --add safe.directory "*"
+
+      - name: Generate N peripheral Verilog (GPIO, UART)
+        run: |
+          docker exec -w /workspace/elemrv/digital-twin elemrv-test bash -c '
+            sbt "runMain elemrv_n.test.WishboneGpioNVerilog" &&
+            sbt "runMain elemrv_n.test.WishboneUartLiteVerilog"'
+
+      - name: Build N co-simulation libraries (libgpio_n.so, libuart_lite.so)
+        run: |
+          docker exec elemrv-test bash -c '
+            cd /workspace/elemrv/digital-twin/renode/verilated/wrappers &&
+            bash build_n_cosim.sh release'
+
+      - name: Initialize Zephyr workspace
+        run: |
+          docker exec elemrv-test bash -c '
+            cd /workspace/elemrv/digital-twin/zephyr &&
+            west init -l elemrv-zephyr 2>/dev/null || true &&
+            west update'
+
+      - name: Build Zephyr blinky for elemrv_n
+        run: |
+          docker exec elemrv-test bash -c '
+            export ZEPHYR_BASE=/workspace/elemrv/digital-twin/zephyr/zephyr &&
+            cd /workspace/elemrv/digital-twin/zephyr/elemrv-zephyr &&
+            west build -b elemrv_n app/blinky -d build-n-blinky'
+
+      - name: Run digital twin tests (5-test slice)
+        run: |
+          docker exec elemrv-test bash -c '
+            cd /workspace/elemrv/digital-twin/renode &&
+            bash run_tests.sh'
+
+      - name: Collect test logs
+        if: always()
+        run: |
+          mkdir -p test-logs
+          for i in 1 2 3 4 5; do
+            docker cp elemrv-test:/tmp/dt_test_${i}.log test-logs/ 2>/dev/null || true
+          done
+          docker cp elemrv-test:/tmp/dt_verilator_tb.log test-logs/ 2>/dev/null || true
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: digital-twin-test-logs
+          path: test-logs/
+
+      - name: Cleanup
+        if: always()
+        run: docker rm -f elemrv-test || true

--- a/digital-twin/README.md
+++ b/digital-twin/README.md
@@ -1,0 +1,105 @@
+# ElemRV Digital Twin
+
+Cycle-accurate Verilator co-simulation of ElemRV peripherals driven from Renode, validated with real firmware (bare-metal and Zephyr) on a system simulator. No FPGA, no silicon.
+
+This first slice ships the **ElemRV-N + GPIO + UART** end-to-end path: Scala -> Verilog -> Verilator -> Renode -> Zephyr blinky. Scope was set with the maintainer in https://github.com/aesc-silicon/ElemRV/issues/13.
+
+## What is in this slice
+
+| Layer | Files |
+| --- | --- |
+| Standalone SBT sub-project | `digital-twin/build.sbt`, `digital-twin/REUSE.toml` |
+| SpinalHDL generators (ElemRV-N) | `digital-twin/scala/elemrv_n/WishboneGpioNVerilog.scala`, `WishboneUartLiteVerilog.scala` |
+| Pre-built Verilog (reproducible) | `digital-twin/gen_n/WishboneGpio.v`, `WishboneUart.v` |
+| Verilator wrappers + Makefiles | `digital-twin/renode/verilated/wrappers/{gpio_n_wrapper.cpp,uart_lite_wrapper.cpp,Makefile.gpio_n,Makefile.uart_lite,build_n_cosim.sh}` |
+| Renode platforms (.repl) | `digital-twin/renode/platforms/elemrv_n{,_cosim_gpio,_cosim_uart_lite,_zephyr}.repl` |
+| Renode run scripts (.resc) | `digital-twin/renode/run_n_{base,cosim_gpio,cosim_uart_lite,zephyr_blinky}_test.resc` |
+| Pure Verilator testbenches | `digital-twin/renode/verilated/testbenches/{Makefile.nitrogen,tb_gpio_n.cpp,tb_uart_lite.cpp,wb_helpers.h}` |
+| Test runner | `digital-twin/renode/run_tests.sh` (5 tests) |
+| Zephyr 4.1 module | `digital-twin/zephyr/elemrv-zephyr/` (board `aesc/elemrv_n`, SoC `elemrv_n_vexriscv`, `app/blinky`) |
+| CI workflow | `.github/workflows/digital-twin-tests.yaml` (`workflow_dispatch` only) |
+
+## Container requirements
+
+The Digital Twin reuses `aesc-silicon/elements-container` (https://github.com/aesc-silicon/elements-container/blob/main/Containerfile). At main today the image already provides sbt, JDK 11, Python 3 + `west`, CMake, ninja, the Zephyr SDK with `riscv64-zephyr-elf`, Renode and Verilator, so the cosim build and `west build` work out of the box.
+
+The DT only relies on the simulation-side bits of that image. Worth double-checking when you bump versions:
+
+- **Renode**: needs 1.16.0 or newer (we use the `RegisterAccessFlags` API path). The image is currently on 1.16.1, fine. The cosim Makefiles read `RENODE_ROOT` and default to `/opt/renode_1.16.0_portable`. If the install path in the container differs (the apt `.deb` puts pieces under `/usr/lib/renode`), export `RENODE_ROOT` to whatever directory contains `plugins/IntegrationLibrary/`. `renode` itself must be on `PATH`.
+- **Verilator**: needs v5.006 or newer. The wrappers will not build against 4.x. The Makefiles invoke `verilator` from `PATH`.
+- **Zephyr SDK**: needs the `riscv64-zephyr-elf` toolchain installed (Zephyr 4.1 works with SDK 0.17.0 or 1.0.x). `ZEPHYR_SDK_INSTALL_DIR` should point at the SDK root.
+- **device-tree-compiler (`dtc`)**: Zephyr needs it. Currently not in the final stage of `elements-container`; adding `device-tree-compiler` to the apt list there is the only addition we expect.
+
+That's it; everything else (sbt, JDK, CMake, ninja, west, Python deps, RISC-V toolchain) is already in the image.
+
+## Build and run, end-to-end
+
+All commands assume the simulation container is running with the repo mounted at `/workspace/elemrv` (CI does this automatically).
+
+```bash
+# 0. Bootstrap nafarr + zibal (idempotent)
+task install
+
+# 1. Generate ElemRV-N peripheral Verilog
+cd digital-twin
+sbt "runMain elemrv_n.test.WishboneGpioNVerilog"
+sbt "runMain elemrv_n.test.WishboneUartLiteVerilog"
+cd ..
+
+# 2. Build Verilator co-simulation libraries
+cd digital-twin/renode/verilated/wrappers
+bash build_n_cosim.sh release
+cd ../../../..
+# Produces digital-twin/renode/verilated/libs/{libgpio_n.so,libuart_lite.so}.
+
+# 3. Set up Zephyr and build the blinky app
+cd digital-twin/zephyr
+west init -l elemrv-zephyr 2>/dev/null || true
+west update
+cd elemrv-zephyr
+west build -b elemrv_n app/blinky -d build-n-blinky
+cd ../../..
+
+# 4. Run the 5-test suite
+cd digital-twin/renode
+bash run_tests.sh
+# SUMMARY: 5/5 passed
+```
+
+## Tests in this slice
+
+| # | Name | Script | Pass marker |
+| --- | --- | --- | --- |
+| 1 | N Base Platform | `run_n_base_test.resc` | `ElemRV-N Base Platform Test PASSED` |
+| 2 | N GPIO Co-simulation | `run_n_cosim_gpio_test.resc` | `N GPIO Co-simulation Test PASSED` |
+| 3 | N UART Lite Co-simulation | `run_n_cosim_uart_lite_test.resc` | `N UART Lite Co-simulation Test PASSED` |
+| 4 | N Pure Verilator Testbenches | `Makefile.nitrogen run` | `All N testbenches PASSED` |
+| 5 | N Zephyr Blinky | `run_n_zephyr_blinky.resc` | `N Zephyr Blinky Test PASSED` |
+
+Tests 2 and 3 skip cleanly if the corresponding `.so` is not built. Test 5 skips if the Zephyr ELF is missing.
+
+## Memory map (ElemRV-N base)
+
+| Region | Address | Size | Notes |
+| --- | --- | --- | --- |
+| RAM | `0x80000000` | 4 KiB | data (XIP keeps code in flash) |
+| HyperRAM | `0x90000000` | 64 MiB | external |
+| Flash | `0xA0000000` | 64 KiB | XIP code |
+| GPIO0 | `0xF0000000` | 4 KiB | 20 pins; co-sim swaps to `WishboneGpio` |
+| I2C0 | `0xF0001000` | 4 KiB | LiteX I2C |
+| UART0 | `0xF0006000` | 4 KiB | LiteX UART (console) |
+| UART1 (cosim slot) | `0xF0007000` | 4 KiB | swapped to `WishboneUart` in `elemrv_n_cosim_uart_lite.repl` |
+| Timer0 | `0xF0020000` | 4 KiB | LiteX Timer (CSR32) |
+
+## Follow-ups (separate PRs)
+
+- ElemRV-H base + PWM driver and PWM co-simulation (Daniel flagged PWM as interesting in https://github.com/aesc-silicon/ElemRV/issues/13#issuecomment-4351154911).
+- Pinmux, SPI, I2C co-simulation for ElemRV-N (drivers/spi/pinctrl wiring, `aesc,nafarr-spi` DT binding).
+- BMB co-simulation + SPI XIP (Phase G).
+- CPU-driven XIP via tlib executable-IO (Phase I).
+- RTOS thread-aware debug demo, fault injection harness, multi-node IoT demo.
+- Taskfile integration (Daniel offered to add the Taskfile/environment plumbing).
+
+## License
+
+Code is under Apache-2.0; generated Verilog and hardware-doc content are CERN-OHL-W-2.0 (see `digital-twin/REUSE.toml`). Existing SPDX headers take precedence; the REUSE annotations only fill gaps.

--- a/digital-twin/REUSE.toml
+++ b/digital-twin/REUSE.toml
@@ -1,0 +1,41 @@
+version = 1
+
+# ---------------------------------------------------------------------------
+# Digital Twin REUSE annotations.
+#
+# Paths in [[annotations]] are relative to this REUSE.toml file (i.e. to
+# `digital-twin/`). REUSE 3.3 supports nested REUSE.toml files; this one
+# applies only to files under `digital-twin/**` while the upstream root
+# `REUSE.toml` covers everything outside.
+#
+# In-file SPDX headers (when present) take precedence over these
+# annotations; the entries here only fill gaps for files that ship
+# without inline headers, e.g. generated Verilog, doc sub-trees,
+# build artefacts.
+# ---------------------------------------------------------------------------
+
+# Default fallback for the whole DT subtree: Apache-2.0 for executable
+# code / firmware / scripts. Files under `docs/**` and `gen_n/**` get
+# overridden below.
+[[annotations]]
+path = "**"
+SPDX-FileCopyrightText = "2025 aesc silicon"
+SPDX-License-Identifier = "Apache-2.0"
+
+# Digital Twin documentation prefers the hardware-doc license.
+[[annotations]]
+path = "docs/**"
+SPDX-FileCopyrightText = "2025 aesc silicon"
+SPDX-License-Identifier = "CERN-OHL-W-2.0"
+
+# Generated Verilog (reproducible output of digital-twin/scala/**).
+[[annotations]]
+path = "gen_n/**"
+SPDX-FileCopyrightText = "2025 aesc silicon"
+SPDX-License-Identifier = "CERN-OHL-W-2.0"
+
+# Tracked .gitignore files inside the DT subtree.
+[[annotations]]
+path = "**/.gitignore"
+SPDX-FileCopyrightText = "2025 aesc silicon"
+SPDX-License-Identifier = "CERN-OHL-W-2.0"

--- a/digital-twin/build.sbt
+++ b/digital-twin/build.sbt
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2025 aesc silicon
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Standalone SBT sub-project for the Digital Twin Verilog generators.
+//
+// Invoke from this directory:
+//   cd digital-twin && sbt "runMain elemrv_n.test.WishboneGpioNVerilog"
+//
+// The DT generators in this slice only depend on nafarr + SpinalHDL;
+// they do not import anything from the upstream `hardware/scala/`
+// tree nor from zibal, so this project stays isolated from the
+// upstream root build.
+
+val spinalVersion = "1.13.0"
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "ElemRV-DigitalTwin",
+    inThisBuild(
+      List(
+        organization := "com.github.spinalhdl",
+        scalaVersion := "2.12.18",
+        version := "1.0.0"
+      )
+    ),
+    libraryDependencies ++= Seq(
+      "com.github.spinalhdl" % "spinalhdl-core_2.12" % spinalVersion,
+      "com.github.spinalhdl" % "spinalhdl-lib_2.12" % spinalVersion,
+      compilerPlugin("com.github.spinalhdl" % "spinalhdl-idsl-plugin_2.12" % spinalVersion)
+    ),
+    Compile / scalaSource := baseDirectory.value / "scala"
+  )
+  .dependsOn(nafarr)
+
+lazy val nafarr = RootProject(file("../modules/elements/nafarr/"))
+
+run / connectInput := true
+fork := true

--- a/digital-twin/gen_n/WishboneGpio.v
+++ b/digital-twin/gen_n/WishboneGpio.v
@@ -1,0 +1,782 @@
+// Generator : SpinalHDL v1.13.0    git head : d9d72474863badf47d8585d187f3e04ae4749c59
+// Component : WishboneGpio
+// Git hash  : 58d827afb766b3e54c8e02d57b05f468cf844e91
+
+`timescale 1ns/1ps
+
+module WishboneGpio (
+  input  wire          io_bus_CYC,
+  input  wire          io_bus_STB,
+  output wire          io_bus_ACK,
+  input  wire          io_bus_WE,
+  input  wire [9:0]    io_bus_ADR,
+  output reg  [31:0]   io_bus_DAT_MISO,
+  input  wire [31:0]   io_bus_DAT_MOSI,
+  input  wire [19:0]   io_gpio_pins_read,
+  output wire [19:0]   io_gpio_pins_write,
+  output wire [19:0]   io_gpio_pins_writeEnable,
+  output wire          io_interrupt,
+  input  wire          clk,
+  input  wire          resetn
+);
+
+  reg        [19:0]   ctrl_io_config_write;
+  reg        [19:0]   ctrl_io_config_direction;
+  reg        [19:0]   ctrl_io_irqHigh_pending;
+  reg        [19:0]   ctrl_io_irqLow_pending;
+  reg        [19:0]   ctrl_io_irqRise_pending;
+  reg        [19:0]   ctrl_io_irqFall_pending;
+  reg        [19:0]   interruptCtrl_4_io_inputs;
+  reg        [19:0]   interruptCtrl_4_io_clears;
+  reg        [19:0]   interruptCtrl_5_io_inputs;
+  reg        [19:0]   interruptCtrl_5_io_clears;
+  reg        [19:0]   interruptCtrl_6_io_inputs;
+  reg        [19:0]   interruptCtrl_6_io_clears;
+  reg        [19:0]   interruptCtrl_7_io_inputs;
+  reg        [19:0]   interruptCtrl_7_io_clears;
+  wire       [19:0]   ctrl_io_gpio_pins_write;
+  wire       [19:0]   ctrl_io_gpio_pins_writeEnable;
+  wire       [19:0]   ctrl_io_value;
+  wire                ctrl_io_interrupt;
+  wire       [19:0]   ctrl_io_irqHigh_valid;
+  wire       [19:0]   ctrl_io_irqLow_valid;
+  wire       [19:0]   ctrl_io_irqRise_valid;
+  wire       [19:0]   ctrl_io_irqFall_valid;
+  wire       [31:0]   mapper_idCtrl_io_header;
+  wire       [31:0]   mapper_idCtrl_io_version;
+  wire       [19:0]   interruptCtrl_4_io_pendings;
+  wire       [19:0]   interruptCtrl_5_io_pendings;
+  wire       [19:0]   interruptCtrl_6_io_pendings;
+  wire       [19:0]   interruptCtrl_7_io_pendings;
+  wire       [11:0]   _zz_2;
+  wire                _zz_1;
+  reg                 _zz_io_bus_ACK;
+  reg        [19:0]   io_masks_driver;
+  reg        [19:0]   io_masks_driver_1;
+  reg        [19:0]   io_masks_driver_2;
+  reg        [19:0]   io_masks_driver_3;
+  reg                 _zz_io_bus_DAT_MISO;
+  wire                _zz_io_bus_DAT_MISO_1;
+  reg                 _zz_io_bus_DAT_MISO_2;
+  wire                _zz_io_bus_DAT_MISO_3;
+  reg                 _zz_io_bus_DAT_MISO_4;
+  wire                _zz_io_bus_DAT_MISO_5;
+  reg                 _zz_io_bus_DAT_MISO_6;
+  wire                _zz_io_bus_DAT_MISO_7;
+  reg                 _zz_io_bus_DAT_MISO_8;
+  wire                _zz_io_bus_DAT_MISO_9;
+  reg                 _zz_io_bus_DAT_MISO_10;
+  wire                _zz_io_bus_DAT_MISO_11;
+  reg                 _zz_io_bus_DAT_MISO_12;
+  wire                _zz_io_bus_DAT_MISO_13;
+  reg                 _zz_io_bus_DAT_MISO_14;
+  wire                _zz_io_bus_DAT_MISO_15;
+  reg                 _zz_io_bus_DAT_MISO_16;
+  wire                _zz_io_bus_DAT_MISO_17;
+  reg                 _zz_io_bus_DAT_MISO_18;
+  wire                _zz_io_bus_DAT_MISO_19;
+  reg                 _zz_io_bus_DAT_MISO_20;
+  wire                _zz_io_bus_DAT_MISO_21;
+  reg                 _zz_io_bus_DAT_MISO_22;
+  wire                _zz_io_bus_DAT_MISO_23;
+  reg                 _zz_io_bus_DAT_MISO_24;
+  wire                _zz_io_bus_DAT_MISO_25;
+  reg                 _zz_io_bus_DAT_MISO_26;
+  wire                _zz_io_bus_DAT_MISO_27;
+  reg                 _zz_io_bus_DAT_MISO_28;
+  wire                _zz_io_bus_DAT_MISO_29;
+  reg                 _zz_io_bus_DAT_MISO_30;
+  wire                _zz_io_bus_DAT_MISO_31;
+  reg                 _zz_io_bus_DAT_MISO_32;
+  wire                _zz_io_bus_DAT_MISO_33;
+  reg                 _zz_io_bus_DAT_MISO_34;
+  wire                _zz_io_bus_DAT_MISO_35;
+  reg                 _zz_io_bus_DAT_MISO_36;
+  wire                _zz_io_bus_DAT_MISO_37;
+  reg                 _zz_io_bus_DAT_MISO_38;
+  wire                _zz_io_bus_DAT_MISO_39;
+
+  assign _zz_2 = ({2'd0,io_bus_ADR} <<< 2'd2);
+  GpioCtrl ctrl (
+    .io_gpio_pins_read        (io_gpio_pins_read[19:0]            ), //i
+    .io_gpio_pins_write       (ctrl_io_gpio_pins_write[19:0]      ), //o
+    .io_gpio_pins_writeEnable (ctrl_io_gpio_pins_writeEnable[19:0]), //o
+    .io_config_write          (ctrl_io_config_write[19:0]         ), //i
+    .io_config_direction      (ctrl_io_config_direction[19:0]     ), //i
+    .io_value                 (ctrl_io_value[19:0]                ), //o
+    .io_interrupt             (ctrl_io_interrupt                  ), //o
+    .io_irqHigh_valid         (ctrl_io_irqHigh_valid[19:0]        ), //o
+    .io_irqHigh_pending       (ctrl_io_irqHigh_pending[19:0]      ), //i
+    .io_irqLow_valid          (ctrl_io_irqLow_valid[19:0]         ), //o
+    .io_irqLow_pending        (ctrl_io_irqLow_pending[19:0]       ), //i
+    .io_irqRise_valid         (ctrl_io_irqRise_valid[19:0]        ), //o
+    .io_irqRise_pending       (ctrl_io_irqRise_pending[19:0]      ), //i
+    .io_irqFall_valid         (ctrl_io_irqFall_valid[19:0]        ), //o
+    .io_irqFall_pending       (ctrl_io_irqFall_pending[19:0]      ), //i
+    .clk                      (clk                                ), //i
+    .resetn                   (resetn                             )  //i
+  );
+  IpIdentificationCtrl mapper_idCtrl (
+    .io_header  (mapper_idCtrl_io_header[31:0] ), //o
+    .io_version (mapper_idCtrl_io_version[31:0]), //o
+    .clk        (clk                           ), //i
+    .resetn     (resetn                        )  //i
+  );
+  InterruptCtrl interruptCtrl_4 (
+    .io_inputs   (interruptCtrl_4_io_inputs[19:0]  ), //i
+    .io_clears   (interruptCtrl_4_io_clears[19:0]  ), //i
+    .io_masks    (io_masks_driver[19:0]            ), //i
+    .io_pendings (interruptCtrl_4_io_pendings[19:0]), //o
+    .clk         (clk                              ), //i
+    .resetn      (resetn                           )  //i
+  );
+  InterruptCtrl interruptCtrl_5 (
+    .io_inputs   (interruptCtrl_5_io_inputs[19:0]  ), //i
+    .io_clears   (interruptCtrl_5_io_clears[19:0]  ), //i
+    .io_masks    (io_masks_driver_1[19:0]          ), //i
+    .io_pendings (interruptCtrl_5_io_pendings[19:0]), //o
+    .clk         (clk                              ), //i
+    .resetn      (resetn                           )  //i
+  );
+  InterruptCtrl interruptCtrl_6 (
+    .io_inputs   (interruptCtrl_6_io_inputs[19:0]  ), //i
+    .io_clears   (interruptCtrl_6_io_clears[19:0]  ), //i
+    .io_masks    (io_masks_driver_2[19:0]          ), //i
+    .io_pendings (interruptCtrl_6_io_pendings[19:0]), //o
+    .clk         (clk                              ), //i
+    .resetn      (resetn                           )  //i
+  );
+  InterruptCtrl interruptCtrl_7 (
+    .io_inputs   (interruptCtrl_7_io_inputs[19:0]  ), //i
+    .io_clears   (interruptCtrl_7_io_clears[19:0]  ), //i
+    .io_masks    (io_masks_driver_3[19:0]          ), //i
+    .io_pendings (interruptCtrl_7_io_pendings[19:0]), //o
+    .clk         (clk                              ), //i
+    .resetn      (resetn                           )  //i
+  );
+  assign io_gpio_pins_write = ctrl_io_gpio_pins_write;
+  assign io_gpio_pins_writeEnable = ctrl_io_gpio_pins_writeEnable;
+  assign io_interrupt = ctrl_io_interrupt;
+  always @(*) begin
+    io_bus_DAT_MISO = 32'h0;
+    case(_zz_2)
+      12'h0 : begin
+        io_bus_DAT_MISO[31 : 0] = mapper_idCtrl_io_header;
+      end
+      12'h004 : begin
+        io_bus_DAT_MISO[31 : 0] = mapper_idCtrl_io_version;
+      end
+      12'h008 : begin
+        io_bus_DAT_MISO[31 : 0] = {16'h0001,16'h0014};
+      end
+      12'h018 : begin
+        io_bus_DAT_MISO[19 : 0] = interruptCtrl_4_io_pendings;
+      end
+      12'h01c : begin
+        io_bus_DAT_MISO[19 : 0] = io_masks_driver;
+      end
+      12'h020 : begin
+        io_bus_DAT_MISO[19 : 0] = interruptCtrl_5_io_pendings;
+      end
+      12'h024 : begin
+        io_bus_DAT_MISO[19 : 0] = io_masks_driver_1;
+      end
+      12'h028 : begin
+        io_bus_DAT_MISO[19 : 0] = interruptCtrl_6_io_pendings;
+      end
+      12'h02c : begin
+        io_bus_DAT_MISO[19 : 0] = io_masks_driver_2;
+      end
+      12'h030 : begin
+        io_bus_DAT_MISO[19 : 0] = interruptCtrl_7_io_pendings;
+      end
+      12'h034 : begin
+        io_bus_DAT_MISO[19 : 0] = io_masks_driver_3;
+      end
+      12'h00c : begin
+        io_bus_DAT_MISO[0 : 0] = ctrl_io_value[0];
+        io_bus_DAT_MISO[1 : 1] = ctrl_io_value[1];
+        io_bus_DAT_MISO[2 : 2] = ctrl_io_value[2];
+        io_bus_DAT_MISO[3 : 3] = ctrl_io_value[3];
+        io_bus_DAT_MISO[4 : 4] = ctrl_io_value[4];
+        io_bus_DAT_MISO[5 : 5] = ctrl_io_value[5];
+        io_bus_DAT_MISO[6 : 6] = ctrl_io_value[6];
+        io_bus_DAT_MISO[7 : 7] = ctrl_io_value[7];
+        io_bus_DAT_MISO[8 : 8] = ctrl_io_value[8];
+        io_bus_DAT_MISO[9 : 9] = ctrl_io_value[9];
+        io_bus_DAT_MISO[10 : 10] = ctrl_io_value[10];
+        io_bus_DAT_MISO[11 : 11] = ctrl_io_value[11];
+        io_bus_DAT_MISO[12 : 12] = ctrl_io_value[12];
+        io_bus_DAT_MISO[13 : 13] = ctrl_io_value[13];
+        io_bus_DAT_MISO[14 : 14] = ctrl_io_value[14];
+        io_bus_DAT_MISO[15 : 15] = ctrl_io_value[15];
+        io_bus_DAT_MISO[16 : 16] = ctrl_io_value[16];
+        io_bus_DAT_MISO[17 : 17] = ctrl_io_value[17];
+        io_bus_DAT_MISO[18 : 18] = ctrl_io_value[18];
+        io_bus_DAT_MISO[19 : 19] = ctrl_io_value[19];
+      end
+      12'h010 : begin
+        io_bus_DAT_MISO[0 : 0] = _zz_io_bus_DAT_MISO;
+        io_bus_DAT_MISO[1 : 1] = _zz_io_bus_DAT_MISO_2;
+        io_bus_DAT_MISO[2 : 2] = _zz_io_bus_DAT_MISO_4;
+        io_bus_DAT_MISO[3 : 3] = _zz_io_bus_DAT_MISO_6;
+        io_bus_DAT_MISO[4 : 4] = _zz_io_bus_DAT_MISO_8;
+        io_bus_DAT_MISO[5 : 5] = _zz_io_bus_DAT_MISO_10;
+        io_bus_DAT_MISO[6 : 6] = _zz_io_bus_DAT_MISO_12;
+        io_bus_DAT_MISO[7 : 7] = _zz_io_bus_DAT_MISO_14;
+        io_bus_DAT_MISO[8 : 8] = _zz_io_bus_DAT_MISO_16;
+        io_bus_DAT_MISO[9 : 9] = _zz_io_bus_DAT_MISO_18;
+        io_bus_DAT_MISO[10 : 10] = _zz_io_bus_DAT_MISO_20;
+        io_bus_DAT_MISO[11 : 11] = _zz_io_bus_DAT_MISO_22;
+        io_bus_DAT_MISO[12 : 12] = _zz_io_bus_DAT_MISO_24;
+        io_bus_DAT_MISO[13 : 13] = _zz_io_bus_DAT_MISO_26;
+        io_bus_DAT_MISO[14 : 14] = _zz_io_bus_DAT_MISO_28;
+        io_bus_DAT_MISO[15 : 15] = _zz_io_bus_DAT_MISO_30;
+        io_bus_DAT_MISO[16 : 16] = _zz_io_bus_DAT_MISO_32;
+        io_bus_DAT_MISO[17 : 17] = _zz_io_bus_DAT_MISO_34;
+        io_bus_DAT_MISO[18 : 18] = _zz_io_bus_DAT_MISO_36;
+        io_bus_DAT_MISO[19 : 19] = _zz_io_bus_DAT_MISO_38;
+      end
+      12'h014 : begin
+        io_bus_DAT_MISO[0 : 0] = _zz_io_bus_DAT_MISO_1;
+        io_bus_DAT_MISO[1 : 1] = _zz_io_bus_DAT_MISO_3;
+        io_bus_DAT_MISO[2 : 2] = _zz_io_bus_DAT_MISO_5;
+        io_bus_DAT_MISO[3 : 3] = _zz_io_bus_DAT_MISO_7;
+        io_bus_DAT_MISO[4 : 4] = _zz_io_bus_DAT_MISO_9;
+        io_bus_DAT_MISO[5 : 5] = _zz_io_bus_DAT_MISO_11;
+        io_bus_DAT_MISO[6 : 6] = _zz_io_bus_DAT_MISO_13;
+        io_bus_DAT_MISO[7 : 7] = _zz_io_bus_DAT_MISO_15;
+        io_bus_DAT_MISO[8 : 8] = _zz_io_bus_DAT_MISO_17;
+        io_bus_DAT_MISO[9 : 9] = _zz_io_bus_DAT_MISO_19;
+        io_bus_DAT_MISO[10 : 10] = _zz_io_bus_DAT_MISO_21;
+        io_bus_DAT_MISO[11 : 11] = _zz_io_bus_DAT_MISO_23;
+        io_bus_DAT_MISO[12 : 12] = _zz_io_bus_DAT_MISO_25;
+        io_bus_DAT_MISO[13 : 13] = _zz_io_bus_DAT_MISO_27;
+        io_bus_DAT_MISO[14 : 14] = _zz_io_bus_DAT_MISO_29;
+        io_bus_DAT_MISO[15 : 15] = _zz_io_bus_DAT_MISO_31;
+        io_bus_DAT_MISO[16 : 16] = _zz_io_bus_DAT_MISO_33;
+        io_bus_DAT_MISO[17 : 17] = _zz_io_bus_DAT_MISO_35;
+        io_bus_DAT_MISO[18 : 18] = _zz_io_bus_DAT_MISO_37;
+        io_bus_DAT_MISO[19 : 19] = _zz_io_bus_DAT_MISO_39;
+      end
+      default : begin
+      end
+    endcase
+  end
+
+  assign _zz_1 = (((io_bus_CYC && io_bus_STB) && ((io_bus_CYC && io_bus_ACK) && io_bus_STB)) && io_bus_WE);
+  assign io_bus_ACK = (_zz_io_bus_ACK && io_bus_STB);
+  always @(*) begin
+    interruptCtrl_4_io_clears = 20'h0;
+    case(_zz_2)
+      12'h018 : begin
+        if(_zz_1) begin
+          interruptCtrl_4_io_clears = io_bus_DAT_MOSI[19 : 0];
+        end
+      end
+      default : begin
+      end
+    endcase
+  end
+
+  always @(*) begin
+    interruptCtrl_5_io_clears = 20'h0;
+    case(_zz_2)
+      12'h020 : begin
+        if(_zz_1) begin
+          interruptCtrl_5_io_clears = io_bus_DAT_MOSI[19 : 0];
+        end
+      end
+      default : begin
+      end
+    endcase
+  end
+
+  always @(*) begin
+    interruptCtrl_6_io_clears = 20'h0;
+    case(_zz_2)
+      12'h028 : begin
+        if(_zz_1) begin
+          interruptCtrl_6_io_clears = io_bus_DAT_MOSI[19 : 0];
+        end
+      end
+      default : begin
+      end
+    endcase
+  end
+
+  always @(*) begin
+    interruptCtrl_7_io_clears = 20'h0;
+    case(_zz_2)
+      12'h030 : begin
+        if(_zz_1) begin
+          interruptCtrl_7_io_clears = io_bus_DAT_MOSI[19 : 0];
+        end
+      end
+      default : begin
+      end
+    endcase
+  end
+
+  always @(*) begin
+    ctrl_io_config_write[0] = _zz_io_bus_DAT_MISO;
+    ctrl_io_config_write[1] = _zz_io_bus_DAT_MISO_2;
+    ctrl_io_config_write[2] = _zz_io_bus_DAT_MISO_4;
+    ctrl_io_config_write[3] = _zz_io_bus_DAT_MISO_6;
+    ctrl_io_config_write[4] = _zz_io_bus_DAT_MISO_8;
+    ctrl_io_config_write[5] = _zz_io_bus_DAT_MISO_10;
+    ctrl_io_config_write[6] = _zz_io_bus_DAT_MISO_12;
+    ctrl_io_config_write[7] = _zz_io_bus_DAT_MISO_14;
+    ctrl_io_config_write[8] = _zz_io_bus_DAT_MISO_16;
+    ctrl_io_config_write[9] = _zz_io_bus_DAT_MISO_18;
+    ctrl_io_config_write[10] = _zz_io_bus_DAT_MISO_20;
+    ctrl_io_config_write[11] = _zz_io_bus_DAT_MISO_22;
+    ctrl_io_config_write[12] = _zz_io_bus_DAT_MISO_24;
+    ctrl_io_config_write[13] = _zz_io_bus_DAT_MISO_26;
+    ctrl_io_config_write[14] = _zz_io_bus_DAT_MISO_28;
+    ctrl_io_config_write[15] = _zz_io_bus_DAT_MISO_30;
+    ctrl_io_config_write[16] = _zz_io_bus_DAT_MISO_32;
+    ctrl_io_config_write[17] = _zz_io_bus_DAT_MISO_34;
+    ctrl_io_config_write[18] = _zz_io_bus_DAT_MISO_36;
+    ctrl_io_config_write[19] = _zz_io_bus_DAT_MISO_38;
+  end
+
+  assign _zz_io_bus_DAT_MISO_1 = 1'b1;
+  always @(*) begin
+    ctrl_io_config_direction[0] = _zz_io_bus_DAT_MISO_1;
+    ctrl_io_config_direction[1] = _zz_io_bus_DAT_MISO_3;
+    ctrl_io_config_direction[2] = _zz_io_bus_DAT_MISO_5;
+    ctrl_io_config_direction[3] = _zz_io_bus_DAT_MISO_7;
+    ctrl_io_config_direction[4] = _zz_io_bus_DAT_MISO_9;
+    ctrl_io_config_direction[5] = _zz_io_bus_DAT_MISO_11;
+    ctrl_io_config_direction[6] = _zz_io_bus_DAT_MISO_13;
+    ctrl_io_config_direction[7] = _zz_io_bus_DAT_MISO_15;
+    ctrl_io_config_direction[8] = _zz_io_bus_DAT_MISO_17;
+    ctrl_io_config_direction[9] = _zz_io_bus_DAT_MISO_19;
+    ctrl_io_config_direction[10] = _zz_io_bus_DAT_MISO_21;
+    ctrl_io_config_direction[11] = _zz_io_bus_DAT_MISO_23;
+    ctrl_io_config_direction[12] = _zz_io_bus_DAT_MISO_25;
+    ctrl_io_config_direction[13] = _zz_io_bus_DAT_MISO_27;
+    ctrl_io_config_direction[14] = _zz_io_bus_DAT_MISO_29;
+    ctrl_io_config_direction[15] = _zz_io_bus_DAT_MISO_31;
+    ctrl_io_config_direction[16] = _zz_io_bus_DAT_MISO_33;
+    ctrl_io_config_direction[17] = _zz_io_bus_DAT_MISO_35;
+    ctrl_io_config_direction[18] = _zz_io_bus_DAT_MISO_37;
+    ctrl_io_config_direction[19] = _zz_io_bus_DAT_MISO_39;
+  end
+
+  always @(*) begin
+    interruptCtrl_4_io_inputs[0] = ctrl_io_irqHigh_valid[0];
+    interruptCtrl_4_io_inputs[1] = ctrl_io_irqHigh_valid[1];
+    interruptCtrl_4_io_inputs[2] = ctrl_io_irqHigh_valid[2];
+    interruptCtrl_4_io_inputs[3] = ctrl_io_irqHigh_valid[3];
+    interruptCtrl_4_io_inputs[4] = ctrl_io_irqHigh_valid[4];
+    interruptCtrl_4_io_inputs[5] = ctrl_io_irqHigh_valid[5];
+    interruptCtrl_4_io_inputs[6] = ctrl_io_irqHigh_valid[6];
+    interruptCtrl_4_io_inputs[7] = ctrl_io_irqHigh_valid[7];
+    interruptCtrl_4_io_inputs[8] = ctrl_io_irqHigh_valid[8];
+    interruptCtrl_4_io_inputs[9] = ctrl_io_irqHigh_valid[9];
+    interruptCtrl_4_io_inputs[10] = ctrl_io_irqHigh_valid[10];
+    interruptCtrl_4_io_inputs[11] = ctrl_io_irqHigh_valid[11];
+    interruptCtrl_4_io_inputs[12] = ctrl_io_irqHigh_valid[12];
+    interruptCtrl_4_io_inputs[13] = ctrl_io_irqHigh_valid[13];
+    interruptCtrl_4_io_inputs[14] = ctrl_io_irqHigh_valid[14];
+    interruptCtrl_4_io_inputs[15] = ctrl_io_irqHigh_valid[15];
+    interruptCtrl_4_io_inputs[16] = ctrl_io_irqHigh_valid[16];
+    interruptCtrl_4_io_inputs[17] = ctrl_io_irqHigh_valid[17];
+    interruptCtrl_4_io_inputs[18] = ctrl_io_irqHigh_valid[18];
+    interruptCtrl_4_io_inputs[19] = ctrl_io_irqHigh_valid[19];
+  end
+
+  always @(*) begin
+    interruptCtrl_5_io_inputs[0] = ctrl_io_irqLow_valid[0];
+    interruptCtrl_5_io_inputs[1] = ctrl_io_irqLow_valid[1];
+    interruptCtrl_5_io_inputs[2] = ctrl_io_irqLow_valid[2];
+    interruptCtrl_5_io_inputs[3] = ctrl_io_irqLow_valid[3];
+    interruptCtrl_5_io_inputs[4] = ctrl_io_irqLow_valid[4];
+    interruptCtrl_5_io_inputs[5] = ctrl_io_irqLow_valid[5];
+    interruptCtrl_5_io_inputs[6] = ctrl_io_irqLow_valid[6];
+    interruptCtrl_5_io_inputs[7] = ctrl_io_irqLow_valid[7];
+    interruptCtrl_5_io_inputs[8] = ctrl_io_irqLow_valid[8];
+    interruptCtrl_5_io_inputs[9] = ctrl_io_irqLow_valid[9];
+    interruptCtrl_5_io_inputs[10] = ctrl_io_irqLow_valid[10];
+    interruptCtrl_5_io_inputs[11] = ctrl_io_irqLow_valid[11];
+    interruptCtrl_5_io_inputs[12] = ctrl_io_irqLow_valid[12];
+    interruptCtrl_5_io_inputs[13] = ctrl_io_irqLow_valid[13];
+    interruptCtrl_5_io_inputs[14] = ctrl_io_irqLow_valid[14];
+    interruptCtrl_5_io_inputs[15] = ctrl_io_irqLow_valid[15];
+    interruptCtrl_5_io_inputs[16] = ctrl_io_irqLow_valid[16];
+    interruptCtrl_5_io_inputs[17] = ctrl_io_irqLow_valid[17];
+    interruptCtrl_5_io_inputs[18] = ctrl_io_irqLow_valid[18];
+    interruptCtrl_5_io_inputs[19] = ctrl_io_irqLow_valid[19];
+  end
+
+  always @(*) begin
+    interruptCtrl_6_io_inputs[0] = ctrl_io_irqRise_valid[0];
+    interruptCtrl_6_io_inputs[1] = ctrl_io_irqRise_valid[1];
+    interruptCtrl_6_io_inputs[2] = ctrl_io_irqRise_valid[2];
+    interruptCtrl_6_io_inputs[3] = ctrl_io_irqRise_valid[3];
+    interruptCtrl_6_io_inputs[4] = ctrl_io_irqRise_valid[4];
+    interruptCtrl_6_io_inputs[5] = ctrl_io_irqRise_valid[5];
+    interruptCtrl_6_io_inputs[6] = ctrl_io_irqRise_valid[6];
+    interruptCtrl_6_io_inputs[7] = ctrl_io_irqRise_valid[7];
+    interruptCtrl_6_io_inputs[8] = ctrl_io_irqRise_valid[8];
+    interruptCtrl_6_io_inputs[9] = ctrl_io_irqRise_valid[9];
+    interruptCtrl_6_io_inputs[10] = ctrl_io_irqRise_valid[10];
+    interruptCtrl_6_io_inputs[11] = ctrl_io_irqRise_valid[11];
+    interruptCtrl_6_io_inputs[12] = ctrl_io_irqRise_valid[12];
+    interruptCtrl_6_io_inputs[13] = ctrl_io_irqRise_valid[13];
+    interruptCtrl_6_io_inputs[14] = ctrl_io_irqRise_valid[14];
+    interruptCtrl_6_io_inputs[15] = ctrl_io_irqRise_valid[15];
+    interruptCtrl_6_io_inputs[16] = ctrl_io_irqRise_valid[16];
+    interruptCtrl_6_io_inputs[17] = ctrl_io_irqRise_valid[17];
+    interruptCtrl_6_io_inputs[18] = ctrl_io_irqRise_valid[18];
+    interruptCtrl_6_io_inputs[19] = ctrl_io_irqRise_valid[19];
+  end
+
+  always @(*) begin
+    interruptCtrl_7_io_inputs[0] = ctrl_io_irqFall_valid[0];
+    interruptCtrl_7_io_inputs[1] = ctrl_io_irqFall_valid[1];
+    interruptCtrl_7_io_inputs[2] = ctrl_io_irqFall_valid[2];
+    interruptCtrl_7_io_inputs[3] = ctrl_io_irqFall_valid[3];
+    interruptCtrl_7_io_inputs[4] = ctrl_io_irqFall_valid[4];
+    interruptCtrl_7_io_inputs[5] = ctrl_io_irqFall_valid[5];
+    interruptCtrl_7_io_inputs[6] = ctrl_io_irqFall_valid[6];
+    interruptCtrl_7_io_inputs[7] = ctrl_io_irqFall_valid[7];
+    interruptCtrl_7_io_inputs[8] = ctrl_io_irqFall_valid[8];
+    interruptCtrl_7_io_inputs[9] = ctrl_io_irqFall_valid[9];
+    interruptCtrl_7_io_inputs[10] = ctrl_io_irqFall_valid[10];
+    interruptCtrl_7_io_inputs[11] = ctrl_io_irqFall_valid[11];
+    interruptCtrl_7_io_inputs[12] = ctrl_io_irqFall_valid[12];
+    interruptCtrl_7_io_inputs[13] = ctrl_io_irqFall_valid[13];
+    interruptCtrl_7_io_inputs[14] = ctrl_io_irqFall_valid[14];
+    interruptCtrl_7_io_inputs[15] = ctrl_io_irqFall_valid[15];
+    interruptCtrl_7_io_inputs[16] = ctrl_io_irqFall_valid[16];
+    interruptCtrl_7_io_inputs[17] = ctrl_io_irqFall_valid[17];
+    interruptCtrl_7_io_inputs[18] = ctrl_io_irqFall_valid[18];
+    interruptCtrl_7_io_inputs[19] = ctrl_io_irqFall_valid[19];
+  end
+
+  always @(*) begin
+    ctrl_io_irqHigh_pending[0] = interruptCtrl_4_io_pendings[0];
+    ctrl_io_irqHigh_pending[1] = interruptCtrl_4_io_pendings[1];
+    ctrl_io_irqHigh_pending[2] = interruptCtrl_4_io_pendings[2];
+    ctrl_io_irqHigh_pending[3] = interruptCtrl_4_io_pendings[3];
+    ctrl_io_irqHigh_pending[4] = interruptCtrl_4_io_pendings[4];
+    ctrl_io_irqHigh_pending[5] = interruptCtrl_4_io_pendings[5];
+    ctrl_io_irqHigh_pending[6] = interruptCtrl_4_io_pendings[6];
+    ctrl_io_irqHigh_pending[7] = interruptCtrl_4_io_pendings[7];
+    ctrl_io_irqHigh_pending[8] = interruptCtrl_4_io_pendings[8];
+    ctrl_io_irqHigh_pending[9] = interruptCtrl_4_io_pendings[9];
+    ctrl_io_irqHigh_pending[10] = interruptCtrl_4_io_pendings[10];
+    ctrl_io_irqHigh_pending[11] = interruptCtrl_4_io_pendings[11];
+    ctrl_io_irqHigh_pending[12] = interruptCtrl_4_io_pendings[12];
+    ctrl_io_irqHigh_pending[13] = interruptCtrl_4_io_pendings[13];
+    ctrl_io_irqHigh_pending[14] = interruptCtrl_4_io_pendings[14];
+    ctrl_io_irqHigh_pending[15] = interruptCtrl_4_io_pendings[15];
+    ctrl_io_irqHigh_pending[16] = interruptCtrl_4_io_pendings[16];
+    ctrl_io_irqHigh_pending[17] = interruptCtrl_4_io_pendings[17];
+    ctrl_io_irqHigh_pending[18] = interruptCtrl_4_io_pendings[18];
+    ctrl_io_irqHigh_pending[19] = interruptCtrl_4_io_pendings[19];
+  end
+
+  always @(*) begin
+    ctrl_io_irqLow_pending[0] = interruptCtrl_5_io_pendings[0];
+    ctrl_io_irqLow_pending[1] = interruptCtrl_5_io_pendings[1];
+    ctrl_io_irqLow_pending[2] = interruptCtrl_5_io_pendings[2];
+    ctrl_io_irqLow_pending[3] = interruptCtrl_5_io_pendings[3];
+    ctrl_io_irqLow_pending[4] = interruptCtrl_5_io_pendings[4];
+    ctrl_io_irqLow_pending[5] = interruptCtrl_5_io_pendings[5];
+    ctrl_io_irqLow_pending[6] = interruptCtrl_5_io_pendings[6];
+    ctrl_io_irqLow_pending[7] = interruptCtrl_5_io_pendings[7];
+    ctrl_io_irqLow_pending[8] = interruptCtrl_5_io_pendings[8];
+    ctrl_io_irqLow_pending[9] = interruptCtrl_5_io_pendings[9];
+    ctrl_io_irqLow_pending[10] = interruptCtrl_5_io_pendings[10];
+    ctrl_io_irqLow_pending[11] = interruptCtrl_5_io_pendings[11];
+    ctrl_io_irqLow_pending[12] = interruptCtrl_5_io_pendings[12];
+    ctrl_io_irqLow_pending[13] = interruptCtrl_5_io_pendings[13];
+    ctrl_io_irqLow_pending[14] = interruptCtrl_5_io_pendings[14];
+    ctrl_io_irqLow_pending[15] = interruptCtrl_5_io_pendings[15];
+    ctrl_io_irqLow_pending[16] = interruptCtrl_5_io_pendings[16];
+    ctrl_io_irqLow_pending[17] = interruptCtrl_5_io_pendings[17];
+    ctrl_io_irqLow_pending[18] = interruptCtrl_5_io_pendings[18];
+    ctrl_io_irqLow_pending[19] = interruptCtrl_5_io_pendings[19];
+  end
+
+  always @(*) begin
+    ctrl_io_irqRise_pending[0] = interruptCtrl_6_io_pendings[0];
+    ctrl_io_irqRise_pending[1] = interruptCtrl_6_io_pendings[1];
+    ctrl_io_irqRise_pending[2] = interruptCtrl_6_io_pendings[2];
+    ctrl_io_irqRise_pending[3] = interruptCtrl_6_io_pendings[3];
+    ctrl_io_irqRise_pending[4] = interruptCtrl_6_io_pendings[4];
+    ctrl_io_irqRise_pending[5] = interruptCtrl_6_io_pendings[5];
+    ctrl_io_irqRise_pending[6] = interruptCtrl_6_io_pendings[6];
+    ctrl_io_irqRise_pending[7] = interruptCtrl_6_io_pendings[7];
+    ctrl_io_irqRise_pending[8] = interruptCtrl_6_io_pendings[8];
+    ctrl_io_irqRise_pending[9] = interruptCtrl_6_io_pendings[9];
+    ctrl_io_irqRise_pending[10] = interruptCtrl_6_io_pendings[10];
+    ctrl_io_irqRise_pending[11] = interruptCtrl_6_io_pendings[11];
+    ctrl_io_irqRise_pending[12] = interruptCtrl_6_io_pendings[12];
+    ctrl_io_irqRise_pending[13] = interruptCtrl_6_io_pendings[13];
+    ctrl_io_irqRise_pending[14] = interruptCtrl_6_io_pendings[14];
+    ctrl_io_irqRise_pending[15] = interruptCtrl_6_io_pendings[15];
+    ctrl_io_irqRise_pending[16] = interruptCtrl_6_io_pendings[16];
+    ctrl_io_irqRise_pending[17] = interruptCtrl_6_io_pendings[17];
+    ctrl_io_irqRise_pending[18] = interruptCtrl_6_io_pendings[18];
+    ctrl_io_irqRise_pending[19] = interruptCtrl_6_io_pendings[19];
+  end
+
+  always @(*) begin
+    ctrl_io_irqFall_pending[0] = interruptCtrl_7_io_pendings[0];
+    ctrl_io_irqFall_pending[1] = interruptCtrl_7_io_pendings[1];
+    ctrl_io_irqFall_pending[2] = interruptCtrl_7_io_pendings[2];
+    ctrl_io_irqFall_pending[3] = interruptCtrl_7_io_pendings[3];
+    ctrl_io_irqFall_pending[4] = interruptCtrl_7_io_pendings[4];
+    ctrl_io_irqFall_pending[5] = interruptCtrl_7_io_pendings[5];
+    ctrl_io_irqFall_pending[6] = interruptCtrl_7_io_pendings[6];
+    ctrl_io_irqFall_pending[7] = interruptCtrl_7_io_pendings[7];
+    ctrl_io_irqFall_pending[8] = interruptCtrl_7_io_pendings[8];
+    ctrl_io_irqFall_pending[9] = interruptCtrl_7_io_pendings[9];
+    ctrl_io_irqFall_pending[10] = interruptCtrl_7_io_pendings[10];
+    ctrl_io_irqFall_pending[11] = interruptCtrl_7_io_pendings[11];
+    ctrl_io_irqFall_pending[12] = interruptCtrl_7_io_pendings[12];
+    ctrl_io_irqFall_pending[13] = interruptCtrl_7_io_pendings[13];
+    ctrl_io_irqFall_pending[14] = interruptCtrl_7_io_pendings[14];
+    ctrl_io_irqFall_pending[15] = interruptCtrl_7_io_pendings[15];
+    ctrl_io_irqFall_pending[16] = interruptCtrl_7_io_pendings[16];
+    ctrl_io_irqFall_pending[17] = interruptCtrl_7_io_pendings[17];
+    ctrl_io_irqFall_pending[18] = interruptCtrl_7_io_pendings[18];
+    ctrl_io_irqFall_pending[19] = interruptCtrl_7_io_pendings[19];
+  end
+
+  assign _zz_io_bus_DAT_MISO_3 = 1'b1;
+  assign _zz_io_bus_DAT_MISO_5 = 1'b1;
+  assign _zz_io_bus_DAT_MISO_7 = 1'b1;
+  assign _zz_io_bus_DAT_MISO_9 = 1'b1;
+  assign _zz_io_bus_DAT_MISO_11 = 1'b1;
+  assign _zz_io_bus_DAT_MISO_13 = 1'b1;
+  assign _zz_io_bus_DAT_MISO_15 = 1'b1;
+  assign _zz_io_bus_DAT_MISO_17 = 1'b1;
+  assign _zz_io_bus_DAT_MISO_19 = 1'b1;
+  assign _zz_io_bus_DAT_MISO_21 = 1'b1;
+  assign _zz_io_bus_DAT_MISO_23 = 1'b1;
+  assign _zz_io_bus_DAT_MISO_25 = 1'b1;
+  assign _zz_io_bus_DAT_MISO_27 = 1'b1;
+  assign _zz_io_bus_DAT_MISO_29 = 1'b1;
+  assign _zz_io_bus_DAT_MISO_31 = 1'b1;
+  assign _zz_io_bus_DAT_MISO_33 = 1'b1;
+  assign _zz_io_bus_DAT_MISO_35 = 1'b1;
+  assign _zz_io_bus_DAT_MISO_37 = 1'b1;
+  assign _zz_io_bus_DAT_MISO_39 = 1'b1;
+  always @(posedge clk or negedge resetn) begin
+    if(!resetn) begin
+      _zz_io_bus_ACK <= 1'b0;
+      io_masks_driver <= 20'h0;
+      io_masks_driver_1 <= 20'h0;
+      io_masks_driver_2 <= 20'h0;
+      io_masks_driver_3 <= 20'h0;
+      _zz_io_bus_DAT_MISO <= 1'b0;
+      _zz_io_bus_DAT_MISO_2 <= 1'b0;
+      _zz_io_bus_DAT_MISO_4 <= 1'b0;
+      _zz_io_bus_DAT_MISO_6 <= 1'b0;
+      _zz_io_bus_DAT_MISO_8 <= 1'b0;
+      _zz_io_bus_DAT_MISO_10 <= 1'b0;
+      _zz_io_bus_DAT_MISO_12 <= 1'b0;
+      _zz_io_bus_DAT_MISO_14 <= 1'b0;
+      _zz_io_bus_DAT_MISO_16 <= 1'b0;
+      _zz_io_bus_DAT_MISO_18 <= 1'b0;
+      _zz_io_bus_DAT_MISO_20 <= 1'b0;
+      _zz_io_bus_DAT_MISO_22 <= 1'b0;
+      _zz_io_bus_DAT_MISO_24 <= 1'b0;
+      _zz_io_bus_DAT_MISO_26 <= 1'b0;
+      _zz_io_bus_DAT_MISO_28 <= 1'b0;
+      _zz_io_bus_DAT_MISO_30 <= 1'b0;
+      _zz_io_bus_DAT_MISO_32 <= 1'b0;
+      _zz_io_bus_DAT_MISO_34 <= 1'b0;
+      _zz_io_bus_DAT_MISO_36 <= 1'b0;
+      _zz_io_bus_DAT_MISO_38 <= 1'b0;
+    end else begin
+      _zz_io_bus_ACK <= (io_bus_STB && io_bus_CYC);
+      case(_zz_2)
+        12'h01c : begin
+          if(_zz_1) begin
+            io_masks_driver <= io_bus_DAT_MOSI[19 : 0];
+          end
+        end
+        12'h024 : begin
+          if(_zz_1) begin
+            io_masks_driver_1 <= io_bus_DAT_MOSI[19 : 0];
+          end
+        end
+        12'h02c : begin
+          if(_zz_1) begin
+            io_masks_driver_2 <= io_bus_DAT_MOSI[19 : 0];
+          end
+        end
+        12'h034 : begin
+          if(_zz_1) begin
+            io_masks_driver_3 <= io_bus_DAT_MOSI[19 : 0];
+          end
+        end
+        12'h010 : begin
+          if(_zz_1) begin
+            _zz_io_bus_DAT_MISO <= io_bus_DAT_MOSI[0];
+            _zz_io_bus_DAT_MISO_2 <= io_bus_DAT_MOSI[1];
+            _zz_io_bus_DAT_MISO_4 <= io_bus_DAT_MOSI[2];
+            _zz_io_bus_DAT_MISO_6 <= io_bus_DAT_MOSI[3];
+            _zz_io_bus_DAT_MISO_8 <= io_bus_DAT_MOSI[4];
+            _zz_io_bus_DAT_MISO_10 <= io_bus_DAT_MOSI[5];
+            _zz_io_bus_DAT_MISO_12 <= io_bus_DAT_MOSI[6];
+            _zz_io_bus_DAT_MISO_14 <= io_bus_DAT_MOSI[7];
+            _zz_io_bus_DAT_MISO_16 <= io_bus_DAT_MOSI[8];
+            _zz_io_bus_DAT_MISO_18 <= io_bus_DAT_MOSI[9];
+            _zz_io_bus_DAT_MISO_20 <= io_bus_DAT_MOSI[10];
+            _zz_io_bus_DAT_MISO_22 <= io_bus_DAT_MOSI[11];
+            _zz_io_bus_DAT_MISO_24 <= io_bus_DAT_MOSI[12];
+            _zz_io_bus_DAT_MISO_26 <= io_bus_DAT_MOSI[13];
+            _zz_io_bus_DAT_MISO_28 <= io_bus_DAT_MOSI[14];
+            _zz_io_bus_DAT_MISO_30 <= io_bus_DAT_MOSI[15];
+            _zz_io_bus_DAT_MISO_32 <= io_bus_DAT_MOSI[16];
+            _zz_io_bus_DAT_MISO_34 <= io_bus_DAT_MOSI[17];
+            _zz_io_bus_DAT_MISO_36 <= io_bus_DAT_MOSI[18];
+            _zz_io_bus_DAT_MISO_38 <= io_bus_DAT_MOSI[19];
+          end
+        end
+        default : begin
+        end
+      endcase
+    end
+  end
+
+
+endmodule
+
+//InterruptCtrl_3 replaced by InterruptCtrl
+
+//InterruptCtrl_2 replaced by InterruptCtrl
+
+//InterruptCtrl_1 replaced by InterruptCtrl
+
+module InterruptCtrl (
+  input  wire [19:0]   io_inputs,
+  input  wire [19:0]   io_clears,
+  input  wire [19:0]   io_masks,
+  output wire [19:0]   io_pendings,
+  input  wire          clk,
+  input  wire          resetn
+);
+
+  reg        [19:0]   pendings;
+
+  assign io_pendings = (pendings & io_masks);
+  always @(posedge clk or negedge resetn) begin
+    if(!resetn) begin
+      pendings <= 20'h0;
+    end else begin
+      pendings <= ((pendings & (~ io_clears)) | io_inputs);
+    end
+  end
+
+
+endmodule
+
+module IpIdentificationCtrl (
+  output wire [31:0]   io_header,
+  output wire [31:0]   io_version,
+  input  wire          clk,
+  input  wire          resetn
+);
+  localparam Ids_Gpio = 4'd0;
+  localparam Ids_Pio = 4'd1;
+  localparam Ids_Pwm = 4'd2;
+  localparam Ids_Uart = 4'd3;
+  localparam Ids_I2cController = 4'd4;
+  localparam Ids_I2cDevice = 4'd5;
+  localparam Ids_SpiController = 4'd6;
+  localparam Ids_SpiXipController = 4'd7;
+  localparam Ids_SpiDevice = 4'd8;
+  localparam Ids_AesAccelerator = 4'd9;
+  localparam Ids_AesMaskedAccelerator = 4'd10;
+  localparam Ids_Reset = 4'd11;
+  localparam Ids_Clock = 4'd12;
+
+  wire       [15:0]   _zz_header;
+  wire       [3:0]    _zz_header_1;
+  wire       [31:0]   header;
+  wire       [31:0]   version;
+
+  assign _zz_header_1 = Ids_Gpio;
+  assign _zz_header = {12'd0, _zz_header_1};
+  assign header = {{8'h0,8'h08},_zz_header};
+  assign version = {{8'h01,8'h0},16'h0};
+  assign io_header = header;
+  assign io_version = version;
+
+endmodule
+
+module GpioCtrl (
+  input  wire [19:0]   io_gpio_pins_read,
+  output wire [19:0]   io_gpio_pins_write,
+  output wire [19:0]   io_gpio_pins_writeEnable,
+  input  wire [19:0]   io_config_write,
+  input  wire [19:0]   io_config_direction,
+  output wire [19:0]   io_value,
+  output wire          io_interrupt,
+  output wire [19:0]   io_irqHigh_valid,
+  input  wire [19:0]   io_irqHigh_pending,
+  output wire [19:0]   io_irqLow_valid,
+  input  wire [19:0]   io_irqLow_pending,
+  output wire [19:0]   io_irqRise_valid,
+  input  wire [19:0]   io_irqRise_pending,
+  output wire [19:0]   io_irqFall_valid,
+  input  wire [19:0]   io_irqFall_pending,
+  input  wire          clk,
+  input  wire          resetn
+);
+
+  wire       [19:0]   io_gpio_pins_read_buffercc_io_dataOut;
+  wire       [19:0]   synchronized;
+  reg        [19:0]   last;
+
+  (* keep_hierarchy = "TRUE" *) BufferCC io_gpio_pins_read_buffercc (
+    .io_dataIn  (io_gpio_pins_read[19:0]                    ), //i
+    .io_dataOut (io_gpio_pins_read_buffercc_io_dataOut[19:0]), //o
+    .clk        (clk                                        ), //i
+    .resetn     (resetn                                     )  //i
+  );
+  assign io_value = io_gpio_pins_read_buffercc_io_dataOut;
+  assign synchronized = io_value;
+  assign io_gpio_pins_write = io_config_write;
+  assign io_gpio_pins_writeEnable = io_config_direction;
+  assign io_irqHigh_valid = synchronized;
+  assign io_irqLow_valid = (~ synchronized);
+  assign io_irqRise_valid = (synchronized & (~ last));
+  assign io_irqFall_valid = ((~ synchronized) & last);
+  assign io_interrupt = (|(((io_irqHigh_pending | io_irqLow_pending) | io_irqRise_pending) | io_irqFall_pending));
+  always @(posedge clk) begin
+    last <= synchronized;
+  end
+
+
+endmodule
+
+module BufferCC (
+  input  wire [19:0]   io_dataIn,
+  output wire [19:0]   io_dataOut,
+  input  wire          clk,
+  input  wire          resetn
+);
+
+  (* async_reg = "true" *) reg        [19:0]   buffers_0;
+  (* async_reg = "true" *) reg        [19:0]   buffers_1;
+  (* async_reg = "true" *) reg        [19:0]   buffers_2;
+
+  assign io_dataOut = buffers_2;
+  always @(posedge clk) begin
+    buffers_0 <= io_dataIn;
+    buffers_1 <= buffers_0;
+    buffers_2 <= buffers_1;
+  end
+
+
+endmodule

--- a/digital-twin/gen_n/WishboneUart.v
+++ b/digital-twin/gen_n/WishboneUart.v
@@ -1,0 +1,1211 @@
+// Generator : SpinalHDL v1.13.0    git head : d9d72474863badf47d8585d187f3e04ae4749c59
+// Component : WishboneUart
+// Git hash  : 58d827afb766b3e54c8e02d57b05f468cf844e91
+
+`timescale 1ns/1ps
+
+module WishboneUart (
+  input  wire          io_bus_CYC,
+  input  wire          io_bus_STB,
+  output wire          io_bus_ACK,
+  input  wire          io_bus_WE,
+  input  wire [9:0]    io_bus_ADR,
+  output reg  [31:0]   io_bus_DAT_MISO,
+  input  wire [31:0]   io_bus_DAT_MOSI,
+  output wire          io_uart_txd,
+  input  wire          io_uart_rxd,
+  input  wire          io_uart_cts,
+  output wire          io_uart_rts,
+  output wire          io_interrupt,
+  input  wire          clk,
+  input  wire          resetn
+);
+  localparam ParityType_NONE = 2'd0;
+  localparam ParityType_EVEN = 2'd1;
+  localparam ParityType_ODD = 2'd2;
+  localparam StopType_ONE = 1'd0;
+  localparam StopType_TWO = 1'd1;
+
+  wire                ctrl_io_readIsFull;
+  reg                 io_read_queueWithOccupancy_io_pop_ready;
+  reg        [1:0]    interruptCtrl_1_io_inputs;
+  reg        [1:0]    interruptCtrl_1_io_clears;
+  wire                ctrl_io_uart_txd;
+  wire                ctrl_io_uart_rts;
+  wire                ctrl_io_interrupt;
+  wire                ctrl_io_write_ready;
+  wire                ctrl_io_read_valid;
+  wire       [8:0]    ctrl_io_read_payload;
+  wire       [31:0]   mapper_idCtrl_io_header;
+  wire       [31:0]   mapper_idCtrl_io_version;
+  wire                mapper_tx_streamUnbuffered_queueWithOccupancy_io_push_ready;
+  wire                mapper_tx_streamUnbuffered_queueWithOccupancy_io_pop_valid;
+  wire       [8:0]    mapper_tx_streamUnbuffered_queueWithOccupancy_io_pop_payload;
+  wire       [2:0]    mapper_tx_streamUnbuffered_queueWithOccupancy_io_occupancy;
+  wire       [2:0]    mapper_tx_streamUnbuffered_queueWithOccupancy_io_availability;
+  wire                io_read_queueWithOccupancy_io_push_ready;
+  wire                io_read_queueWithOccupancy_io_pop_valid;
+  wire       [8:0]    io_read_queueWithOccupancy_io_pop_payload;
+  wire       [2:0]    io_read_queueWithOccupancy_io_occupancy;
+  wire       [2:0]    io_read_queueWithOccupancy_io_availability;
+  wire       [1:0]    interruptCtrl_1_io_pendings;
+  wire       [2:0]    _zz_io_inputs;
+  wire       [11:0]   _zz_3;
+  wire                _zz_1;
+  wire                _zz_2;
+  reg                 _zz_io_bus_ACK;
+  wire       [1:0]    mapper_permissionBits;
+  reg                 _zz_mapper_tx_streamUnbuffered_valid;
+  wire                mapper_tx_streamUnbuffered_valid;
+  wire                mapper_tx_streamUnbuffered_ready;
+  wire       [8:0]    mapper_tx_streamUnbuffered_payload;
+  wire       [2:0]    mapper_tx_fifoVacancy;
+  reg        [19:0]   mapper_config_cfg_clockDivider;
+  reg                 mapper_config_cfg_clockDividerReload;
+  reg        [1:0]    mapper_config_frameCfg_parity;
+  reg        [0:0]    mapper_config_frameCfg_stop;
+  reg        [3:0]    mapper_config_frameCfg_dataLength;
+  reg        [2:0]    _zz_io_bus_DAT_MISO;
+  reg        [2:0]    io_occupancy_regNext;
+  reg        [1:0]    io_masks_driver;
+  wire       [1:0]    _zz_mapper_config_frameCfg_parity;
+  wire       [0:0]    _zz_mapper_config_frameCfg_stop;
+  `ifndef SYNTHESIS
+  reg [31:0] mapper_config_frameCfg_parity_string;
+  reg [23:0] mapper_config_frameCfg_stop_string;
+  reg [31:0] _zz_mapper_config_frameCfg_parity_string;
+  reg [23:0] _zz_mapper_config_frameCfg_stop_string;
+  `endif
+
+
+  assign _zz_3 = ({2'd0,io_bus_ADR} <<< 2'd2);
+  assign _zz_io_inputs = (_zz_io_bus_DAT_MISO + 3'b001);
+  UartCtrl ctrl (
+    .io_config_clockDivider       (mapper_config_cfg_clockDivider[19:0]                             ), //i
+    .io_config_clockDividerReload (mapper_config_cfg_clockDividerReload                             ), //i
+    .io_frameConfig_parity        (mapper_config_frameCfg_parity[1:0]                               ), //i
+    .io_frameConfig_stop          (mapper_config_frameCfg_stop                                      ), //i
+    .io_frameConfig_dataLength    (mapper_config_frameCfg_dataLength[3:0]                           ), //i
+    .io_uart_txd                  (ctrl_io_uart_txd                                                 ), //o
+    .io_uart_rxd                  (io_uart_rxd                                                      ), //i
+    .io_uart_cts                  (io_uart_cts                                                      ), //i
+    .io_uart_rts                  (ctrl_io_uart_rts                                                 ), //o
+    .io_interrupt                 (ctrl_io_interrupt                                                ), //o
+    .io_pendingInterrupts         (interruptCtrl_1_io_pendings[1:0]                                 ), //i
+    .io_write_valid               (mapper_tx_streamUnbuffered_queueWithOccupancy_io_pop_valid       ), //i
+    .io_write_ready               (ctrl_io_write_ready                                              ), //o
+    .io_write_payload             (mapper_tx_streamUnbuffered_queueWithOccupancy_io_pop_payload[8:0]), //i
+    .io_read_valid                (ctrl_io_read_valid                                               ), //o
+    .io_read_ready                (io_read_queueWithOccupancy_io_push_ready                         ), //i
+    .io_read_payload              (ctrl_io_read_payload[8:0]                                        ), //o
+    .io_readIsFull                (ctrl_io_readIsFull                                               ), //i
+    .clk                          (clk                                                              ), //i
+    .resetn                       (resetn                                                           )  //i
+  );
+  IpIdentificationCtrl mapper_idCtrl (
+    .io_header  (mapper_idCtrl_io_header[31:0] ), //o
+    .io_version (mapper_idCtrl_io_version[31:0]), //o
+    .clk        (clk                           ), //i
+    .resetn     (resetn                        )  //i
+  );
+  StreamFifo mapper_tx_streamUnbuffered_queueWithOccupancy (
+    .io_push_valid   (mapper_tx_streamUnbuffered_valid                                  ), //i
+    .io_push_ready   (mapper_tx_streamUnbuffered_queueWithOccupancy_io_push_ready       ), //o
+    .io_push_payload (mapper_tx_streamUnbuffered_payload[8:0]                           ), //i
+    .io_pop_valid    (mapper_tx_streamUnbuffered_queueWithOccupancy_io_pop_valid        ), //o
+    .io_pop_ready    (ctrl_io_write_ready                                               ), //i
+    .io_pop_payload  (mapper_tx_streamUnbuffered_queueWithOccupancy_io_pop_payload[8:0] ), //o
+    .io_flush        (1'b0                                                              ), //i
+    .io_occupancy    (mapper_tx_streamUnbuffered_queueWithOccupancy_io_occupancy[2:0]   ), //o
+    .io_availability (mapper_tx_streamUnbuffered_queueWithOccupancy_io_availability[2:0]), //o
+    .clk             (clk                                                               ), //i
+    .resetn          (resetn                                                            )  //i
+  );
+  StreamFifo io_read_queueWithOccupancy (
+    .io_push_valid   (ctrl_io_read_valid                             ), //i
+    .io_push_ready   (io_read_queueWithOccupancy_io_push_ready       ), //o
+    .io_push_payload (ctrl_io_read_payload[8:0]                      ), //i
+    .io_pop_valid    (io_read_queueWithOccupancy_io_pop_valid        ), //o
+    .io_pop_ready    (io_read_queueWithOccupancy_io_pop_ready        ), //i
+    .io_pop_payload  (io_read_queueWithOccupancy_io_pop_payload[8:0] ), //o
+    .io_flush        (1'b0                                           ), //i
+    .io_occupancy    (io_read_queueWithOccupancy_io_occupancy[2:0]   ), //o
+    .io_availability (io_read_queueWithOccupancy_io_availability[2:0]), //o
+    .clk             (clk                                            ), //i
+    .resetn          (resetn                                         )  //i
+  );
+  InterruptCtrl interruptCtrl_1 (
+    .io_inputs   (interruptCtrl_1_io_inputs[1:0]  ), //i
+    .io_clears   (interruptCtrl_1_io_clears[1:0]  ), //i
+    .io_masks    (io_masks_driver[1:0]            ), //i
+    .io_pendings (interruptCtrl_1_io_pendings[1:0]), //o
+    .clk         (clk                             ), //i
+    .resetn      (resetn                          )  //i
+  );
+  `ifndef SYNTHESIS
+  always @(*) begin
+    case(mapper_config_frameCfg_parity)
+      ParityType_NONE : mapper_config_frameCfg_parity_string = "NONE";
+      ParityType_EVEN : mapper_config_frameCfg_parity_string = "EVEN";
+      ParityType_ODD : mapper_config_frameCfg_parity_string = "ODD ";
+      default : mapper_config_frameCfg_parity_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(mapper_config_frameCfg_stop)
+      StopType_ONE : mapper_config_frameCfg_stop_string = "ONE";
+      StopType_TWO : mapper_config_frameCfg_stop_string = "TWO";
+      default : mapper_config_frameCfg_stop_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_mapper_config_frameCfg_parity)
+      ParityType_NONE : _zz_mapper_config_frameCfg_parity_string = "NONE";
+      ParityType_EVEN : _zz_mapper_config_frameCfg_parity_string = "EVEN";
+      ParityType_ODD : _zz_mapper_config_frameCfg_parity_string = "ODD ";
+      default : _zz_mapper_config_frameCfg_parity_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_mapper_config_frameCfg_stop)
+      StopType_ONE : _zz_mapper_config_frameCfg_stop_string = "ONE";
+      StopType_TWO : _zz_mapper_config_frameCfg_stop_string = "TWO";
+      default : _zz_mapper_config_frameCfg_stop_string = "???";
+    endcase
+  end
+  `endif
+
+  assign io_uart_txd = ctrl_io_uart_txd;
+  assign io_uart_rts = ctrl_io_uart_rts;
+  assign io_interrupt = ctrl_io_interrupt;
+  always @(*) begin
+    io_bus_DAT_MISO = 32'h0;
+    case(_zz_3)
+      12'h0 : begin
+        io_bus_DAT_MISO[31 : 0] = mapper_idCtrl_io_header;
+      end
+      12'h004 : begin
+        io_bus_DAT_MISO[31 : 0] = mapper_idCtrl_io_version;
+      end
+      12'h008 : begin
+        io_bus_DAT_MISO[31 : 0] = {{{8'h0,8'h05},8'h09},8'h14};
+      end
+      12'h00c : begin
+        io_bus_DAT_MISO[31 : 0] = {{{8'h0,8'h01},8'h05},8'h02};
+      end
+      12'h010 : begin
+        io_bus_DAT_MISO[31 : 0] = {{16'h0,8'h04},8'h04};
+      end
+      12'h014 : begin
+        io_bus_DAT_MISO[31 : 0] = {30'h0,mapper_permissionBits};
+      end
+      12'h018 : begin
+        io_bus_DAT_MISO[16 : 16] = (io_read_queueWithOccupancy_io_pop_valid ^ 1'b0);
+        io_bus_DAT_MISO[8 : 0] = io_read_queueWithOccupancy_io_pop_payload;
+      end
+      12'h01c : begin
+        io_bus_DAT_MISO[18 : 16] = mapper_tx_fifoVacancy;
+        io_bus_DAT_MISO[26 : 24] = io_read_queueWithOccupancy_io_occupancy;
+      end
+      12'h020 : begin
+        io_bus_DAT_MISO[19 : 0] = mapper_config_cfg_clockDivider;
+      end
+      12'h024 : begin
+        io_bus_DAT_MISO[3 : 0] = mapper_config_frameCfg_dataLength;
+        io_bus_DAT_MISO[9 : 8] = mapper_config_frameCfg_parity;
+        io_bus_DAT_MISO[16 : 16] = mapper_config_frameCfg_stop;
+      end
+      12'h028 : begin
+        io_bus_DAT_MISO[2 : 0] = _zz_io_bus_DAT_MISO;
+      end
+      12'h02c : begin
+        io_bus_DAT_MISO[1 : 0] = interruptCtrl_1_io_pendings;
+      end
+      12'h030 : begin
+        io_bus_DAT_MISO[1 : 0] = io_masks_driver;
+      end
+      default : begin
+      end
+    endcase
+  end
+
+  assign _zz_1 = (((io_bus_CYC && io_bus_STB) && ((io_bus_CYC && io_bus_ACK) && io_bus_STB)) && io_bus_WE);
+  assign _zz_2 = (((io_bus_CYC && io_bus_STB) && ((io_bus_CYC && io_bus_ACK) && io_bus_STB)) && (! io_bus_WE));
+  assign io_bus_ACK = (_zz_io_bus_ACK && io_bus_STB);
+  assign mapper_permissionBits = {1'b1,1'b1};
+  always @(*) begin
+    _zz_mapper_tx_streamUnbuffered_valid = 1'b0;
+    case(_zz_3)
+      12'h018 : begin
+        if(_zz_1) begin
+          _zz_mapper_tx_streamUnbuffered_valid = 1'b1;
+        end
+      end
+      default : begin
+      end
+    endcase
+  end
+
+  assign mapper_tx_streamUnbuffered_valid = _zz_mapper_tx_streamUnbuffered_valid;
+  assign mapper_tx_streamUnbuffered_payload = io_bus_DAT_MOSI[8 : 0];
+  assign mapper_tx_streamUnbuffered_ready = mapper_tx_streamUnbuffered_queueWithOccupancy_io_push_ready;
+  assign mapper_tx_fifoVacancy = (3'b100 - mapper_tx_streamUnbuffered_queueWithOccupancy_io_occupancy);
+  assign ctrl_io_readIsFull = (3'b011 <= io_read_queueWithOccupancy_io_occupancy);
+  always @(*) begin
+    io_read_queueWithOccupancy_io_pop_ready = 1'b0;
+    case(_zz_3)
+      12'h018 : begin
+        if(_zz_2) begin
+          io_read_queueWithOccupancy_io_pop_ready = 1'b1;
+        end
+      end
+      default : begin
+      end
+    endcase
+  end
+
+  always @(*) begin
+    interruptCtrl_1_io_clears = 2'b00;
+    case(_zz_3)
+      12'h02c : begin
+        if(_zz_1) begin
+          interruptCtrl_1_io_clears = io_bus_DAT_MOSI[1 : 0];
+        end
+      end
+      default : begin
+      end
+    endcase
+  end
+
+  always @(*) begin
+    interruptCtrl_1_io_inputs[0] = ((mapper_tx_streamUnbuffered_queueWithOccupancy_io_occupancy == _zz_io_bus_DAT_MISO) && (io_occupancy_regNext == _zz_io_inputs));
+    interruptCtrl_1_io_inputs[1] = ctrl_io_read_valid;
+  end
+
+  assign _zz_mapper_config_frameCfg_parity = io_bus_DAT_MOSI[9 : 8];
+  assign _zz_mapper_config_frameCfg_stop = io_bus_DAT_MOSI[16 : 16];
+  always @(posedge clk or negedge resetn) begin
+    if(!resetn) begin
+      _zz_io_bus_ACK <= 1'b0;
+      io_masks_driver <= 2'b00;
+    end else begin
+      _zz_io_bus_ACK <= (io_bus_STB && io_bus_CYC);
+      case(_zz_3)
+        12'h030 : begin
+          if(_zz_1) begin
+            io_masks_driver <= io_bus_DAT_MOSI[1 : 0];
+          end
+        end
+        default : begin
+        end
+      endcase
+    end
+  end
+
+  always @(posedge clk) begin
+    mapper_config_cfg_clockDividerReload <= 1'b0;
+    io_occupancy_regNext <= mapper_tx_streamUnbuffered_queueWithOccupancy_io_occupancy;
+    case(_zz_3)
+      12'h020 : begin
+        if(_zz_1) begin
+          mapper_config_cfg_clockDivider <= io_bus_DAT_MOSI[19 : 0];
+          mapper_config_cfg_clockDividerReload <= 1'b1;
+        end
+      end
+      12'h024 : begin
+        if(_zz_1) begin
+          mapper_config_frameCfg_dataLength <= io_bus_DAT_MOSI[3 : 0];
+          mapper_config_frameCfg_parity <= _zz_mapper_config_frameCfg_parity;
+          mapper_config_frameCfg_stop <= _zz_mapper_config_frameCfg_stop;
+        end
+      end
+      12'h028 : begin
+        if(_zz_1) begin
+          _zz_io_bus_DAT_MISO <= io_bus_DAT_MOSI[2 : 0];
+        end
+      end
+      default : begin
+      end
+    endcase
+  end
+
+
+endmodule
+
+module InterruptCtrl (
+  input  wire [1:0]    io_inputs,
+  input  wire [1:0]    io_clears,
+  input  wire [1:0]    io_masks,
+  output wire [1:0]    io_pendings,
+  input  wire          clk,
+  input  wire          resetn
+);
+
+  reg        [1:0]    pendings;
+
+  assign io_pendings = (pendings & io_masks);
+  always @(posedge clk or negedge resetn) begin
+    if(!resetn) begin
+      pendings <= 2'b00;
+    end else begin
+      pendings <= ((pendings & (~ io_clears)) | io_inputs);
+    end
+  end
+
+
+endmodule
+
+//StreamFifo_1 replaced by StreamFifo
+
+module StreamFifo (
+  input  wire          io_push_valid,
+  output wire          io_push_ready,
+  input  wire [8:0]    io_push_payload,
+  output wire          io_pop_valid,
+  input  wire          io_pop_ready,
+  output wire [8:0]    io_pop_payload,
+  input  wire          io_flush,
+  output wire [2:0]    io_occupancy,
+  output wire [2:0]    io_availability,
+  input  wire          clk,
+  input  wire          resetn
+);
+
+  reg        [8:0]    logic_ram_spinal_port1;
+  reg                 _zz_1;
+  wire                logic_ptr_doPush;
+  wire                logic_ptr_doPop;
+  wire                logic_ptr_full;
+  wire                logic_ptr_empty;
+  reg        [2:0]    logic_ptr_push;
+  reg        [2:0]    logic_ptr_pop;
+  wire       [2:0]    logic_ptr_occupancy;
+  wire       [2:0]    logic_ptr_popOnIo;
+  wire                when_Stream_l1455;
+  reg                 logic_ptr_wentUp;
+  wire                io_push_fire;
+  wire                logic_push_onRam_write_valid;
+  wire       [1:0]    logic_push_onRam_write_payload_address;
+  wire       [8:0]    logic_push_onRam_write_payload_data;
+  wire                logic_pop_addressGen_valid;
+  reg                 logic_pop_addressGen_ready;
+  wire       [1:0]    logic_pop_addressGen_payload;
+  wire                logic_pop_addressGen_fire;
+  wire                logic_pop_sync_readArbitation_valid;
+  wire                logic_pop_sync_readArbitation_ready;
+  wire       [1:0]    logic_pop_sync_readArbitation_payload;
+  reg                 logic_pop_addressGen_rValid;
+  reg        [1:0]    logic_pop_addressGen_rData;
+  wire                when_Stream_l477;
+  wire                logic_pop_sync_readPort_cmd_valid;
+  wire       [1:0]    logic_pop_sync_readPort_cmd_payload;
+  wire       [8:0]    logic_pop_sync_readPort_rsp;
+  wire                logic_pop_addressGen_toFlowFire_valid;
+  wire       [1:0]    logic_pop_addressGen_toFlowFire_payload;
+  wire                logic_pop_sync_readArbitation_translated_valid;
+  wire                logic_pop_sync_readArbitation_translated_ready;
+  wire       [8:0]    logic_pop_sync_readArbitation_translated_payload;
+  wire                logic_pop_sync_readArbitation_fire;
+  reg        [2:0]    logic_pop_sync_popReg;
+  reg [8:0] logic_ram [0:3];
+
+  always @(posedge clk) begin
+    if(_zz_1) begin
+      logic_ram[logic_push_onRam_write_payload_address] <= logic_push_onRam_write_payload_data;
+    end
+  end
+
+  always @(posedge clk) begin
+    if(logic_pop_sync_readPort_cmd_valid) begin
+      logic_ram_spinal_port1 <= logic_ram[logic_pop_sync_readPort_cmd_payload];
+    end
+  end
+
+  always @(*) begin
+    _zz_1 = 1'b0;
+    if(logic_push_onRam_write_valid) begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  assign when_Stream_l1455 = (logic_ptr_doPush != logic_ptr_doPop);
+  assign logic_ptr_full = (((logic_ptr_push ^ logic_ptr_popOnIo) ^ 3'b100) == 3'b000);
+  assign logic_ptr_empty = (logic_ptr_push == logic_ptr_pop);
+  assign logic_ptr_occupancy = (logic_ptr_push - logic_ptr_popOnIo);
+  assign io_push_ready = (! logic_ptr_full);
+  assign io_push_fire = (io_push_valid && io_push_ready);
+  assign logic_ptr_doPush = io_push_fire;
+  assign logic_push_onRam_write_valid = io_push_fire;
+  assign logic_push_onRam_write_payload_address = logic_ptr_push[1:0];
+  assign logic_push_onRam_write_payload_data = io_push_payload;
+  assign logic_pop_addressGen_valid = (! logic_ptr_empty);
+  assign logic_pop_addressGen_payload = logic_ptr_pop[1:0];
+  assign logic_pop_addressGen_fire = (logic_pop_addressGen_valid && logic_pop_addressGen_ready);
+  assign logic_ptr_doPop = logic_pop_addressGen_fire;
+  always @(*) begin
+    logic_pop_addressGen_ready = logic_pop_sync_readArbitation_ready;
+    if(when_Stream_l477) begin
+      logic_pop_addressGen_ready = 1'b1;
+    end
+  end
+
+  assign when_Stream_l477 = (! logic_pop_sync_readArbitation_valid);
+  assign logic_pop_sync_readArbitation_valid = logic_pop_addressGen_rValid;
+  assign logic_pop_sync_readArbitation_payload = logic_pop_addressGen_rData;
+  assign logic_pop_sync_readPort_rsp = logic_ram_spinal_port1;
+  assign logic_pop_addressGen_toFlowFire_valid = logic_pop_addressGen_fire;
+  assign logic_pop_addressGen_toFlowFire_payload = logic_pop_addressGen_payload;
+  assign logic_pop_sync_readPort_cmd_valid = logic_pop_addressGen_toFlowFire_valid;
+  assign logic_pop_sync_readPort_cmd_payload = logic_pop_addressGen_toFlowFire_payload;
+  assign logic_pop_sync_readArbitation_translated_valid = logic_pop_sync_readArbitation_valid;
+  assign logic_pop_sync_readArbitation_ready = logic_pop_sync_readArbitation_translated_ready;
+  assign logic_pop_sync_readArbitation_translated_payload = logic_pop_sync_readPort_rsp;
+  assign io_pop_valid = logic_pop_sync_readArbitation_translated_valid;
+  assign logic_pop_sync_readArbitation_translated_ready = io_pop_ready;
+  assign io_pop_payload = logic_pop_sync_readArbitation_translated_payload;
+  assign logic_pop_sync_readArbitation_fire = (logic_pop_sync_readArbitation_valid && logic_pop_sync_readArbitation_ready);
+  assign logic_ptr_popOnIo = logic_pop_sync_popReg;
+  assign io_occupancy = logic_ptr_occupancy;
+  assign io_availability = (3'b100 - logic_ptr_occupancy);
+  always @(posedge clk or negedge resetn) begin
+    if(!resetn) begin
+      logic_ptr_push <= 3'b000;
+      logic_ptr_pop <= 3'b000;
+      logic_ptr_wentUp <= 1'b0;
+      logic_pop_addressGen_rValid <= 1'b0;
+      logic_pop_sync_popReg <= 3'b000;
+    end else begin
+      if(when_Stream_l1455) begin
+        logic_ptr_wentUp <= logic_ptr_doPush;
+      end
+      if(io_flush) begin
+        logic_ptr_wentUp <= 1'b0;
+      end
+      if(logic_ptr_doPush) begin
+        logic_ptr_push <= (logic_ptr_push + 3'b001);
+      end
+      if(logic_ptr_doPop) begin
+        logic_ptr_pop <= (logic_ptr_pop + 3'b001);
+      end
+      if(io_flush) begin
+        logic_ptr_push <= 3'b000;
+        logic_ptr_pop <= 3'b000;
+      end
+      if(logic_pop_addressGen_ready) begin
+        logic_pop_addressGen_rValid <= logic_pop_addressGen_valid;
+      end
+      if(io_flush) begin
+        logic_pop_addressGen_rValid <= 1'b0;
+      end
+      if(logic_pop_sync_readArbitation_fire) begin
+        logic_pop_sync_popReg <= logic_ptr_pop;
+      end
+      if(io_flush) begin
+        logic_pop_sync_popReg <= 3'b000;
+      end
+    end
+  end
+
+  always @(posedge clk) begin
+    if(logic_pop_addressGen_ready) begin
+      logic_pop_addressGen_rData <= logic_pop_addressGen_payload;
+    end
+  end
+
+
+endmodule
+
+module IpIdentificationCtrl (
+  output wire [31:0]   io_header,
+  output wire [31:0]   io_version,
+  input  wire          clk,
+  input  wire          resetn
+);
+  localparam Ids_Gpio = 4'd0;
+  localparam Ids_Pio = 4'd1;
+  localparam Ids_Pwm = 4'd2;
+  localparam Ids_Uart = 4'd3;
+  localparam Ids_I2cController = 4'd4;
+  localparam Ids_I2cDevice = 4'd5;
+  localparam Ids_SpiController = 4'd6;
+  localparam Ids_SpiXipController = 4'd7;
+  localparam Ids_SpiDevice = 4'd8;
+  localparam Ids_AesAccelerator = 4'd9;
+  localparam Ids_AesMaskedAccelerator = 4'd10;
+  localparam Ids_Reset = 4'd11;
+  localparam Ids_Clock = 4'd12;
+
+  wire       [15:0]   _zz_header;
+  wire       [3:0]    _zz_header_1;
+  wire       [31:0]   header;
+  wire       [31:0]   version;
+
+  assign _zz_header_1 = Ids_Uart;
+  assign _zz_header = {12'd0, _zz_header_1};
+  assign header = {{8'h0,8'h08},_zz_header};
+  assign version = {{8'h01,8'h0},16'h0};
+  assign io_header = header;
+  assign io_version = version;
+
+endmodule
+
+module UartCtrl (
+  input  wire [19:0]   io_config_clockDivider,
+  input  wire          io_config_clockDividerReload,
+  input  wire [1:0]    io_frameConfig_parity,
+  input  wire [0:0]    io_frameConfig_stop,
+  input  wire [3:0]    io_frameConfig_dataLength,
+  output wire          io_uart_txd,
+  input  wire          io_uart_rxd,
+  input  wire          io_uart_cts,
+  output wire          io_uart_rts,
+  output wire          io_interrupt,
+  input  wire [1:0]    io_pendingInterrupts,
+  input  wire          io_write_valid,
+  output wire          io_write_ready,
+  input  wire [8:0]    io_write_payload,
+  output wire          io_read_valid,
+  input  wire          io_read_ready,
+  output wire [8:0]    io_read_payload,
+  input  wire          io_readIsFull,
+  input  wire          clk,
+  input  wire          resetn
+);
+  localparam ParityType_NONE = 2'd0;
+  localparam ParityType_EVEN = 2'd1;
+  localparam ParityType_ODD = 2'd2;
+  localparam StopType_ONE = 1'd0;
+  localparam StopType_TWO = 1'd1;
+
+  wire                tx_io_cts;
+  wire                clockDivider_1_io_tick;
+  wire                tx_io_write_ready;
+  wire                tx_io_txd;
+  wire                rx_io_read_valid;
+  wire       [8:0]    rx_io_read_payload;
+  `ifndef SYNTHESIS
+  reg [31:0] io_frameConfig_parity_string;
+  reg [23:0] io_frameConfig_stop_string;
+  `endif
+
+
+  ClockDivider clockDivider_1 (
+    .io_value  (io_config_clockDivider[19:0]), //i
+    .io_reload (io_config_clockDividerReload), //i
+    .io_tick   (clockDivider_1_io_tick      ), //o
+    .clk       (clk                         ), //i
+    .resetn    (resetn                      )  //i
+  );
+  UartCtrlTx tx (
+    .io_config_parity     (io_frameConfig_parity[1:0]    ), //i
+    .io_config_stop       (io_frameConfig_stop           ), //i
+    .io_config_dataLength (io_frameConfig_dataLength[3:0]), //i
+    .io_samplingTick      (clockDivider_1_io_tick        ), //i
+    .io_write_valid       (io_write_valid                ), //i
+    .io_write_ready       (tx_io_write_ready             ), //o
+    .io_write_payload     (io_write_payload[8:0]         ), //i
+    .io_txd               (tx_io_txd                     ), //o
+    .io_cts               (tx_io_cts                     ), //i
+    .clk                  (clk                           ), //i
+    .resetn               (resetn                        )  //i
+  );
+  UartCtrlRx rx (
+    .io_config_parity     (io_frameConfig_parity[1:0]    ), //i
+    .io_config_stop       (io_frameConfig_stop           ), //i
+    .io_config_dataLength (io_frameConfig_dataLength[3:0]), //i
+    .io_samplingTick      (clockDivider_1_io_tick        ), //i
+    .io_read_valid        (rx_io_read_valid              ), //o
+    .io_read_ready        (io_read_ready                 ), //i
+    .io_read_payload      (rx_io_read_payload[8:0]       ), //o
+    .io_rxd               (io_uart_rxd                   ), //i
+    .clk                  (clk                           ), //i
+    .resetn               (resetn                        )  //i
+  );
+  `ifndef SYNTHESIS
+  always @(*) begin
+    case(io_frameConfig_parity)
+      ParityType_NONE : io_frameConfig_parity_string = "NONE";
+      ParityType_EVEN : io_frameConfig_parity_string = "EVEN";
+      ParityType_ODD : io_frameConfig_parity_string = "ODD ";
+      default : io_frameConfig_parity_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(io_frameConfig_stop)
+      StopType_ONE : io_frameConfig_stop_string = "ONE";
+      StopType_TWO : io_frameConfig_stop_string = "TWO";
+      default : io_frameConfig_stop_string = "???";
+    endcase
+  end
+  `endif
+
+  assign io_interrupt = (|io_pendingInterrupts);
+  assign io_write_ready = tx_io_write_ready;
+  assign io_uart_txd = tx_io_txd;
+  assign io_read_valid = rx_io_read_valid;
+  assign io_read_payload = rx_io_read_payload;
+  assign io_uart_rts = io_readIsFull;
+  assign tx_io_cts = (! io_uart_cts);
+
+endmodule
+
+module UartCtrlRx (
+  input  wire [1:0]    io_config_parity,
+  input  wire [0:0]    io_config_stop,
+  input  wire [3:0]    io_config_dataLength,
+  input  wire          io_samplingTick,
+  output wire          io_read_valid,
+  input  wire          io_read_ready,
+  output wire [8:0]    io_read_payload,
+  input  wire          io_rxd,
+  input  wire          clk,
+  input  wire          resetn
+);
+  localparam ParityType_NONE = 2'd0;
+  localparam ParityType_EVEN = 2'd1;
+  localparam ParityType_ODD = 2'd2;
+  localparam StopType_ONE = 1'd0;
+  localparam StopType_TWO = 1'd1;
+  localparam State_IDLE = 3'd0;
+  localparam State_START = 3'd1;
+  localparam State_DATA = 3'd2;
+  localparam State_PARITY = 3'd3;
+  localparam State_STOP = 3'd4;
+
+  wire                io_rxd_buffercc_io_dataOut;
+  wire                _zz_sampler_value;
+  wire                _zz_sampler_value_1;
+  wire                _zz_sampler_value_2;
+  wire                _zz_sampler_value_3;
+  wire                _zz_sampler_value_4;
+  wire                _zz_sampler_value_5;
+  wire                _zz_sampler_value_6;
+  wire       [3:0]    _zz_when_UartCtrlRx_l129;
+  wire       [0:0]    _zz_when_UartCtrlRx_l129_1;
+  wire                sampler_synchroniser;
+  wire                sampler_samples_0;
+  reg                 sampler_samples_1;
+  reg                 sampler_samples_2;
+  reg                 sampler_samples_3;
+  reg                 sampler_samples_4;
+  reg                 sampler_value;
+  reg                 sampler_tick;
+  reg        [2:0]    bitTimer_counter;
+  reg                 bitTimer_tick;
+  wire                when_UartCtrlRx_l49;
+  reg        [3:0]    bitCounter_value;
+  reg        [2:0]    stateMachine_state;
+  reg                 stateMachine_parity;
+  reg        [8:0]    stateMachine_shifter;
+  reg                 stateMachine_validReg;
+  wire                when_UartCtrlRx_l83;
+  wire                when_UartCtrlRx_l94;
+  wire                when_UartCtrlRx_l102;
+  wire                when_UartCtrlRx_l104;
+  wire                when_UartCtrlRx_l116;
+  wire                when_UartCtrlRx_l127;
+  wire                when_UartCtrlRx_l129;
+  `ifndef SYNTHESIS
+  reg [31:0] io_config_parity_string;
+  reg [23:0] io_config_stop_string;
+  reg [47:0] stateMachine_state_string;
+  `endif
+
+
+  assign _zz_when_UartCtrlRx_l129_1 = ((io_config_stop == StopType_ONE) ? 1'b0 : 1'b1);
+  assign _zz_when_UartCtrlRx_l129 = {3'd0, _zz_when_UartCtrlRx_l129_1};
+  assign _zz_sampler_value = ((((1'b0 || ((_zz_sampler_value_1 && sampler_samples_1) && sampler_samples_2)) || (((_zz_sampler_value_2 && sampler_samples_0) && sampler_samples_1) && sampler_samples_3)) || (((1'b1 && sampler_samples_0) && sampler_samples_2) && sampler_samples_3)) || (((1'b1 && sampler_samples_1) && sampler_samples_2) && sampler_samples_3));
+  assign _zz_sampler_value_3 = (((1'b1 && sampler_samples_0) && sampler_samples_1) && sampler_samples_4);
+  assign _zz_sampler_value_4 = ((1'b1 && sampler_samples_0) && sampler_samples_2);
+  assign _zz_sampler_value_5 = (1'b1 && sampler_samples_1);
+  assign _zz_sampler_value_6 = 1'b1;
+  assign _zz_sampler_value_1 = (1'b1 && sampler_samples_0);
+  assign _zz_sampler_value_2 = 1'b1;
+  (* keep_hierarchy = "TRUE" *) BufferCC io_rxd_buffercc (
+    .io_dataIn  (io_rxd                    ), //i
+    .io_dataOut (io_rxd_buffercc_io_dataOut), //o
+    .clk        (clk                       ), //i
+    .resetn     (resetn                    )  //i
+  );
+  `ifndef SYNTHESIS
+  always @(*) begin
+    case(io_config_parity)
+      ParityType_NONE : io_config_parity_string = "NONE";
+      ParityType_EVEN : io_config_parity_string = "EVEN";
+      ParityType_ODD : io_config_parity_string = "ODD ";
+      default : io_config_parity_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(io_config_stop)
+      StopType_ONE : io_config_stop_string = "ONE";
+      StopType_TWO : io_config_stop_string = "TWO";
+      default : io_config_stop_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(stateMachine_state)
+      State_IDLE : stateMachine_state_string = "IDLE  ";
+      State_START : stateMachine_state_string = "START ";
+      State_DATA : stateMachine_state_string = "DATA  ";
+      State_PARITY : stateMachine_state_string = "PARITY";
+      State_STOP : stateMachine_state_string = "STOP  ";
+      default : stateMachine_state_string = "??????";
+    endcase
+  end
+  `endif
+
+  assign sampler_synchroniser = io_rxd_buffercc_io_dataOut;
+  assign sampler_samples_0 = sampler_synchroniser;
+  always @(*) begin
+    bitTimer_tick = 1'b0;
+    if(sampler_tick) begin
+      if(when_UartCtrlRx_l49) begin
+        bitTimer_tick = 1'b1;
+      end
+    end
+  end
+
+  assign when_UartCtrlRx_l49 = (bitTimer_counter == 3'b000);
+  assign io_read_valid = stateMachine_validReg;
+  assign when_UartCtrlRx_l83 = (sampler_tick && (! sampler_value));
+  assign when_UartCtrlRx_l94 = (sampler_value == 1'b1);
+  assign when_UartCtrlRx_l102 = (bitCounter_value == io_config_dataLength);
+  assign when_UartCtrlRx_l104 = (io_config_parity == ParityType_NONE);
+  assign when_UartCtrlRx_l116 = (stateMachine_parity == sampler_value);
+  assign when_UartCtrlRx_l127 = (! sampler_value);
+  assign when_UartCtrlRx_l129 = (bitCounter_value == _zz_when_UartCtrlRx_l129);
+  assign io_read_payload = stateMachine_shifter;
+  always @(posedge clk or negedge resetn) begin
+    if(!resetn) begin
+      sampler_samples_1 <= 1'b1;
+      sampler_samples_2 <= 1'b1;
+      sampler_samples_3 <= 1'b1;
+      sampler_samples_4 <= 1'b1;
+      sampler_value <= 1'b1;
+      sampler_tick <= 1'b0;
+      stateMachine_state <= State_IDLE;
+      stateMachine_validReg <= 1'b0;
+    end else begin
+      if(io_samplingTick) begin
+        sampler_samples_1 <= sampler_samples_0;
+      end
+      if(io_samplingTick) begin
+        sampler_samples_2 <= sampler_samples_1;
+      end
+      if(io_samplingTick) begin
+        sampler_samples_3 <= sampler_samples_2;
+      end
+      if(io_samplingTick) begin
+        sampler_samples_4 <= sampler_samples_3;
+      end
+      sampler_value <= ((((((_zz_sampler_value || _zz_sampler_value_3) || (_zz_sampler_value_4 && sampler_samples_4)) || ((_zz_sampler_value_5 && sampler_samples_2) && sampler_samples_4)) || (((_zz_sampler_value_6 && sampler_samples_0) && sampler_samples_3) && sampler_samples_4)) || (((1'b1 && sampler_samples_1) && sampler_samples_3) && sampler_samples_4)) || (((1'b1 && sampler_samples_2) && sampler_samples_3) && sampler_samples_4));
+      sampler_tick <= io_samplingTick;
+      stateMachine_validReg <= 1'b0;
+      case(stateMachine_state)
+        State_IDLE : begin
+          if(when_UartCtrlRx_l83) begin
+            stateMachine_state <= State_START;
+          end
+        end
+        State_START : begin
+          if(bitTimer_tick) begin
+            stateMachine_state <= State_DATA;
+            if(when_UartCtrlRx_l94) begin
+              stateMachine_state <= State_IDLE;
+            end
+          end
+        end
+        State_DATA : begin
+          if(bitTimer_tick) begin
+            if(when_UartCtrlRx_l102) begin
+              if(when_UartCtrlRx_l104) begin
+                stateMachine_state <= State_STOP;
+                stateMachine_validReg <= 1'b1;
+              end else begin
+                stateMachine_state <= State_PARITY;
+              end
+            end
+          end
+        end
+        State_PARITY : begin
+          if(bitTimer_tick) begin
+            if(when_UartCtrlRx_l116) begin
+              stateMachine_state <= State_STOP;
+              stateMachine_validReg <= 1'b1;
+            end else begin
+              stateMachine_state <= State_IDLE;
+            end
+          end
+        end
+        default : begin
+          if(bitTimer_tick) begin
+            if(when_UartCtrlRx_l127) begin
+              stateMachine_state <= State_IDLE;
+            end else begin
+              if(when_UartCtrlRx_l129) begin
+                stateMachine_state <= State_IDLE;
+              end
+            end
+          end
+        end
+      endcase
+    end
+  end
+
+  always @(posedge clk) begin
+    if(sampler_tick) begin
+      bitTimer_counter <= (bitTimer_counter - 3'b001);
+    end
+    if(bitTimer_tick) begin
+      bitCounter_value <= (bitCounter_value + 4'b0001);
+    end
+    if(bitTimer_tick) begin
+      stateMachine_parity <= (stateMachine_parity ^ sampler_value);
+    end
+    case(stateMachine_state)
+      State_IDLE : begin
+        if(when_UartCtrlRx_l83) begin
+          bitTimer_counter <= 3'b010;
+        end
+      end
+      State_START : begin
+        if(bitTimer_tick) begin
+          bitCounter_value <= 4'b0000;
+          stateMachine_parity <= (io_config_parity == ParityType_ODD);
+          stateMachine_shifter <= 9'h0;
+        end
+      end
+      State_DATA : begin
+        if(bitTimer_tick) begin
+          stateMachine_shifter[bitCounter_value] <= sampler_value;
+          if(when_UartCtrlRx_l102) begin
+            bitCounter_value <= 4'b0000;
+          end
+        end
+      end
+      State_PARITY : begin
+        if(bitTimer_tick) begin
+          bitCounter_value <= 4'b0000;
+        end
+      end
+      default : begin
+      end
+    endcase
+  end
+
+
+endmodule
+
+module UartCtrlTx (
+  input  wire [1:0]    io_config_parity,
+  input  wire [0:0]    io_config_stop,
+  input  wire [3:0]    io_config_dataLength,
+  input  wire          io_samplingTick,
+  input  wire          io_write_valid,
+  output reg           io_write_ready,
+  input  wire [8:0]    io_write_payload,
+  output wire          io_txd,
+  input  wire          io_cts,
+  input  wire          clk,
+  input  wire          resetn
+);
+  localparam ParityType_NONE = 2'd0;
+  localparam ParityType_EVEN = 2'd1;
+  localparam ParityType_ODD = 2'd2;
+  localparam StopType_ONE = 1'd0;
+  localparam StopType_TWO = 1'd1;
+  localparam State_IDLE = 3'd0;
+  localparam State_START = 3'd1;
+  localparam State_DATA = 3'd2;
+  localparam State_PARITY = 3'd3;
+  localparam State_STOP = 3'd4;
+
+  wire       [2:0]    _zz_txCtrl_clockDivider_counter_valueNext;
+  wire       [0:0]    _zz_txCtrl_clockDivider_counter_valueNext_1;
+  wire       [3:0]    _zz_when_UartCtrlTx_l95;
+  wire       [0:0]    _zz_when_UartCtrlTx_l95_1;
+  reg                 txEnable;
+  wire                txCtrl_newClockEnable;
+  reg                 txCtrl_clockDivider_counter_willIncrement;
+  wire                txCtrl_clockDivider_counter_willClear;
+  reg        [2:0]    txCtrl_clockDivider_counter_valueNext;
+  reg        [2:0]    txCtrl_clockDivider_counter_value;
+  wire                txCtrl_clockDivider_counter_willOverflowIfInc;
+  wire                txCtrl_clockDivider_counter_willOverflow;
+  reg        [3:0]    txCtrl_tickCounter_value;
+  reg        [2:0]    txCtrl_stateMachine_state;
+  reg                 txCtrl_stateMachine_parity;
+  reg                 txCtrl_stateMachine_txd;
+  wire                when_UartCtrlTx_l59;
+  wire                when_UartCtrlTx_l74;
+  wire                when_UartCtrlTx_l77;
+  wire                when_UartCtrlTx_l95;
+  wire       [2:0]    _zz_txCtrl_stateMachine_state;
+  wire                when_UartCtrlTx_l103;
+  reg                 txCtrl_stateMachine_txd_regNext;
+  `ifndef SYNTHESIS
+  reg [31:0] io_config_parity_string;
+  reg [23:0] io_config_stop_string;
+  reg [47:0] txCtrl_stateMachine_state_string;
+  reg [47:0] _zz_txCtrl_stateMachine_state_string;
+  `endif
+
+
+  assign _zz_txCtrl_clockDivider_counter_valueNext_1 = txCtrl_clockDivider_counter_willIncrement;
+  assign _zz_txCtrl_clockDivider_counter_valueNext = {2'd0, _zz_txCtrl_clockDivider_counter_valueNext_1};
+  assign _zz_when_UartCtrlTx_l95_1 = ((io_config_stop == StopType_ONE) ? 1'b0 : 1'b1);
+  assign _zz_when_UartCtrlTx_l95 = {3'd0, _zz_when_UartCtrlTx_l95_1};
+  `ifndef SYNTHESIS
+  always @(*) begin
+    case(io_config_parity)
+      ParityType_NONE : io_config_parity_string = "NONE";
+      ParityType_EVEN : io_config_parity_string = "EVEN";
+      ParityType_ODD : io_config_parity_string = "ODD ";
+      default : io_config_parity_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(io_config_stop)
+      StopType_ONE : io_config_stop_string = "ONE";
+      StopType_TWO : io_config_stop_string = "TWO";
+      default : io_config_stop_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(txCtrl_stateMachine_state)
+      State_IDLE : txCtrl_stateMachine_state_string = "IDLE  ";
+      State_START : txCtrl_stateMachine_state_string = "START ";
+      State_DATA : txCtrl_stateMachine_state_string = "DATA  ";
+      State_PARITY : txCtrl_stateMachine_state_string = "PARITY";
+      State_STOP : txCtrl_stateMachine_state_string = "STOP  ";
+      default : txCtrl_stateMachine_state_string = "??????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_txCtrl_stateMachine_state)
+      State_IDLE : _zz_txCtrl_stateMachine_state_string = "IDLE  ";
+      State_START : _zz_txCtrl_stateMachine_state_string = "START ";
+      State_DATA : _zz_txCtrl_stateMachine_state_string = "DATA  ";
+      State_PARITY : _zz_txCtrl_stateMachine_state_string = "PARITY";
+      State_STOP : _zz_txCtrl_stateMachine_state_string = "STOP  ";
+      default : _zz_txCtrl_stateMachine_state_string = "??????";
+    endcase
+  end
+  `endif
+
+  assign txCtrl_newClockEnable = (1'b1 && txEnable);
+  always @(*) begin
+    txCtrl_clockDivider_counter_willIncrement = 1'b0;
+    if(io_samplingTick) begin
+      txCtrl_clockDivider_counter_willIncrement = 1'b1;
+    end
+  end
+
+  assign txCtrl_clockDivider_counter_willClear = 1'b0;
+  assign txCtrl_clockDivider_counter_willOverflowIfInc = (txCtrl_clockDivider_counter_value == 3'b111);
+  assign txCtrl_clockDivider_counter_willOverflow = (txCtrl_clockDivider_counter_willOverflowIfInc && txCtrl_clockDivider_counter_willIncrement);
+  always @(*) begin
+    txCtrl_clockDivider_counter_valueNext = (txCtrl_clockDivider_counter_value + _zz_txCtrl_clockDivider_counter_valueNext);
+    if(txCtrl_clockDivider_counter_willClear) begin
+      txCtrl_clockDivider_counter_valueNext = 3'b000;
+    end
+  end
+
+  always @(*) begin
+    txCtrl_stateMachine_txd = 1'b1;
+    case(txCtrl_stateMachine_state)
+      State_IDLE : begin
+      end
+      State_START : begin
+        txCtrl_stateMachine_txd = 1'b0;
+      end
+      State_DATA : begin
+        txCtrl_stateMachine_txd = io_write_payload[txCtrl_tickCounter_value];
+      end
+      State_PARITY : begin
+        txCtrl_stateMachine_txd = txCtrl_stateMachine_parity;
+      end
+      default : begin
+      end
+    endcase
+  end
+
+  always @(*) begin
+    io_write_ready = 1'b0;
+    case(txCtrl_stateMachine_state)
+      State_IDLE : begin
+      end
+      State_START : begin
+      end
+      State_DATA : begin
+        if(txCtrl_clockDivider_counter_willOverflow) begin
+          if(when_UartCtrlTx_l74) begin
+            io_write_ready = 1'b1;
+          end
+        end
+      end
+      State_PARITY : begin
+      end
+      default : begin
+      end
+    endcase
+  end
+
+  assign when_UartCtrlTx_l59 = ((io_write_valid && txCtrl_clockDivider_counter_willOverflow) && io_cts);
+  assign when_UartCtrlTx_l74 = (txCtrl_tickCounter_value == io_config_dataLength);
+  assign when_UartCtrlTx_l77 = (io_config_parity == ParityType_NONE);
+  assign when_UartCtrlTx_l95 = (txCtrl_tickCounter_value == _zz_when_UartCtrlTx_l95);
+  assign _zz_txCtrl_stateMachine_state = (io_write_valid ? State_START : State_IDLE);
+  assign when_UartCtrlTx_l103 = (io_write_valid || (! (txCtrl_stateMachine_state == State_IDLE)));
+  assign io_txd = txCtrl_stateMachine_txd_regNext;
+  always @(posedge clk or negedge resetn) begin
+    if(!resetn) begin
+      txEnable <= 1'b1;
+      txCtrl_stateMachine_txd_regNext <= 1'b1;
+    end else begin
+      if(when_UartCtrlTx_l103) begin
+        txEnable <= 1'b1;
+      end else begin
+        txEnable <= 1'b0;
+      end
+      txCtrl_stateMachine_txd_regNext <= txCtrl_stateMachine_txd;
+    end
+  end
+
+  always @(posedge clk or negedge resetn) begin
+    if(!resetn) begin
+      txCtrl_clockDivider_counter_value <= 3'b000;
+      txCtrl_stateMachine_state <= State_IDLE;
+    end else begin
+      if(txCtrl_newClockEnable) begin
+        txCtrl_clockDivider_counter_value <= txCtrl_clockDivider_counter_valueNext;
+        case(txCtrl_stateMachine_state)
+          State_IDLE : begin
+            if(when_UartCtrlTx_l59) begin
+              txCtrl_stateMachine_state <= State_START;
+            end
+          end
+          State_START : begin
+            if(txCtrl_clockDivider_counter_willOverflow) begin
+              txCtrl_stateMachine_state <= State_DATA;
+            end
+          end
+          State_DATA : begin
+            if(txCtrl_clockDivider_counter_willOverflow) begin
+              if(when_UartCtrlTx_l74) begin
+                if(when_UartCtrlTx_l77) begin
+                  txCtrl_stateMachine_state <= State_STOP;
+                end else begin
+                  txCtrl_stateMachine_state <= State_PARITY;
+                end
+              end
+            end
+          end
+          State_PARITY : begin
+            if(txCtrl_clockDivider_counter_willOverflow) begin
+              txCtrl_stateMachine_state <= State_STOP;
+            end
+          end
+          default : begin
+            if(txCtrl_clockDivider_counter_willOverflow) begin
+              if(when_UartCtrlTx_l95) begin
+                txCtrl_stateMachine_state <= _zz_txCtrl_stateMachine_state;
+              end
+            end
+          end
+        endcase
+      end
+    end
+  end
+
+  always @(posedge clk) begin
+    if(txCtrl_newClockEnable) begin
+      if(txCtrl_clockDivider_counter_willOverflow) begin
+        txCtrl_tickCounter_value <= (txCtrl_tickCounter_value + 4'b0001);
+      end
+      if(txCtrl_clockDivider_counter_willOverflow) begin
+        txCtrl_stateMachine_parity <= (txCtrl_stateMachine_parity ^ txCtrl_stateMachine_txd);
+      end
+      case(txCtrl_stateMachine_state)
+        State_IDLE : begin
+        end
+        State_START : begin
+          if(txCtrl_clockDivider_counter_willOverflow) begin
+            txCtrl_stateMachine_parity <= (io_config_parity == ParityType_ODD);
+            txCtrl_tickCounter_value <= 4'b0000;
+          end
+        end
+        State_DATA : begin
+          if(txCtrl_clockDivider_counter_willOverflow) begin
+            if(when_UartCtrlTx_l74) begin
+              txCtrl_tickCounter_value <= 4'b0000;
+            end
+          end
+        end
+        State_PARITY : begin
+          if(txCtrl_clockDivider_counter_willOverflow) begin
+            txCtrl_tickCounter_value <= 4'b0000;
+          end
+        end
+        default : begin
+        end
+      endcase
+    end
+  end
+
+
+endmodule
+
+module ClockDivider (
+  input  wire [19:0]   io_value,
+  input  wire          io_reload,
+  output wire          io_tick,
+  input  wire          clk,
+  input  wire          resetn
+);
+
+  reg        [19:0]   counter;
+  wire                tick;
+  wire                when_ClockDivider_l26;
+
+  assign tick = (counter == 20'h0);
+  assign when_ClockDivider_l26 = (tick || io_reload);
+  assign io_tick = tick;
+  always @(posedge clk or negedge resetn) begin
+    if(!resetn) begin
+      counter <= 20'h0;
+    end else begin
+      counter <= (counter - 20'h00001);
+      if(when_ClockDivider_l26) begin
+        counter <= io_value;
+      end
+    end
+  end
+
+
+endmodule
+
+module BufferCC (
+  input  wire          io_dataIn,
+  output wire          io_dataOut,
+  input  wire          clk,
+  input  wire          resetn
+);
+
+  (* async_reg = "true" *) reg                 buffers_0;
+  (* async_reg = "true" *) reg                 buffers_1;
+
+  assign io_dataOut = buffers_1;
+  always @(posedge clk or negedge resetn) begin
+    if(!resetn) begin
+      buffers_0 <= 1'b0;
+      buffers_1 <= 1'b0;
+    end else begin
+      buffers_0 <= io_dataIn;
+      buffers_1 <= buffers_0;
+    end
+  end
+
+
+endmodule

--- a/digital-twin/renode/platforms/elemrv_n.repl
+++ b/digital-twin/renode/platforms/elemrv_n.repl
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2025 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+// ElemRV-N Platform Description - WITH PERIPHERALS
+// Nitrogen platform - CPU + RAM + HyperRAM + FLASH + Peripherals
+// CPU: VexRiscv RV32IMC @ 20 MHz
+
+// CPU: RISC-V VexRiscv RV32IMC
+cpu: CPU.VexRiscv @ sysbus
+    cpuType: "rv32imc"
+
+// Main RAM: 4 KB @ 0x80000000
+ram: Memory.MappedMemory @ sysbus 0x80000000
+    size: 0x00001000
+
+// HyperRAM: 64 MB @ 0x90000000
+hyperram: Memory.MappedMemory @ sysbus 0x90000000
+    size: 0x04000000
+
+// FLASH: 64 KB @ 0xA0000000
+flash: Memory.MappedMemory @ sysbus 0xA0000000
+    size: 0x00010000
+
+// UART0: LiteX UART @ 0xF0006000
+uart0: UART.LiteX_UART @ sysbus 0xF0006000
+    -> cpu@0
+
+// GPIO0: 20 pins @ 0xF0000000
+gpio0: GPIOPort.LiteX_GPIO @ sysbus 0xF0000000
+    type: Type.Out
+
+// I2C0: LiteX I2C @ 0xF0001000
+i2c0: I2C.LiteX_I2C @ sysbus 0xF0001000
+
+// Timer (for delays)
+timer0: Timers.LiteX_Timer @ sysbus 0xF0020000
+    frequency: 20000000
+    -> cpu@1
+
+// Unsupported peripherals (tagged for access logging)
+sysbus:
+    init:
+        Tag <0xF0002000, +0x1000> "I2C1"
+        Tag <0xF0003000, +0x1000> "PIO0"
+        Tag <0xF0004000, +0x1000> "PWM0"
+        Tag <0xF0005000, +0x1000> "SPI0"
+        Tag <0xF0007000, +0x1000> "UART1"
+        Tag <0xF0010000, +0x1000> "Pinmux"
+        Tag <0xF0023000, +0x1000> "HyperBus Config"

--- a/digital-twin/renode/platforms/elemrv_n_cosim_gpio.repl
+++ b/digital-twin/renode/platforms/elemrv_n_cosim_gpio.repl
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2025 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+// ElemRV-N Platform with GPIO RTL Co-simulation
+
+cpu: CPU.VexRiscv @ sysbus
+    cpuType: "rv32imc"
+
+ram: Memory.MappedMemory @ sysbus 0x80000000
+    size: 0x00001000
+
+hyperram: Memory.MappedMemory @ sysbus 0x90000000
+    size: 0x04000000
+
+flash: Memory.MappedMemory @ sysbus 0xA0000000
+    size: 0x00010000
+
+uart0: UART.LiteX_UART @ sysbus 0xF0006000
+    -> cpu@0
+
+// GPIO0: RTL Co-simulation via Verilator (replaces LiteX_GPIO)
+gpio0_cosim: CoSimulated.CoSimulatedPeripheral @ sysbus <0xF0000000, +0x1000>
+    frequency: 20000000
+    limitBuffer: 10000
+
+i2c0: I2C.LiteX_I2C @ sysbus 0xF0001000
+
+timer0: Timers.LiteX_Timer @ sysbus 0xF0020000
+    frequency: 20000000
+    -> cpu@1
+
+sysbus:
+    init:
+        Tag <0xF0002000, +0x1000> "I2C1"
+        Tag <0xF0003000, +0x1000> "PIO0"
+        Tag <0xF0004000, +0x1000> "PWM0"
+        Tag <0xF0005000, +0x1000> "SPI0"
+        Tag <0xF0007000, +0x1000> "UART1"
+        Tag <0xF0010000, +0x1000> "Pinmux"
+        Tag <0xF0023000, +0x1000> "HyperBus Config"

--- a/digital-twin/renode/platforms/elemrv_n_cosim_uart_lite.repl
+++ b/digital-twin/renode/platforms/elemrv_n_cosim_uart_lite.repl
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2025 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+// ElemRV-N Platform with UART1 (lightweight) RTL Co-simulation
+
+cpu: CPU.VexRiscv @ sysbus
+    cpuType: "rv32imc"
+
+ram: Memory.MappedMemory @ sysbus 0x80000000
+    size: 0x00001000
+
+hyperram: Memory.MappedMemory @ sysbus 0x90000000
+    size: 0x04000000
+
+flash: Memory.MappedMemory @ sysbus 0xA0000000
+    size: 0x00010000
+
+uart0: UART.LiteX_UART @ sysbus 0xF0006000
+    -> cpu@0
+
+gpio0: GPIOPort.LiteX_GPIO @ sysbus 0xF0000000
+    type: Type.Out
+
+i2c0: I2C.LiteX_I2C @ sysbus 0xF0001000
+
+timer0: Timers.LiteX_Timer @ sysbus 0xF0020000
+    frequency: 20000000
+    -> cpu@1
+
+// UART1: RTL Co-simulation via Verilator (lightweight)
+uart1_cosim: CoSimulated.CoSimulatedPeripheral @ sysbus <0xF0007000, +0x1000>
+    frequency: 20000000
+    limitBuffer: 10000
+
+sysbus:
+    init:
+        Tag <0xF0002000, +0x1000> "I2C1"
+        Tag <0xF0003000, +0x1000> "PIO0"
+        Tag <0xF0004000, +0x1000> "PWM0"
+        Tag <0xF0005000, +0x1000> "SPI0"
+        Tag <0xF0010000, +0x1000> "Pinmux"
+        Tag <0xF0023000, +0x1000> "HyperBus Config"

--- a/digital-twin/renode/platforms/elemrv_n_zephyr.repl
+++ b/digital-twin/renode/platforms/elemrv_n_zephyr.repl
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// ElemRV-N Platform for Zephyr RTOS (XIP)
+// Code executes from Flash, data in 4 KB SRAM, matches real HW
+// CPU: VexRiscv RV32IMC @ 20 MHz
+
+cpu: CPU.VexRiscv @ sysbus
+    cpuType: "rv32imc"
+
+// RAM: 4 KB @ 0x80000000 (real HW size)
+ram: Memory.MappedMemory @ sysbus 0x80000000
+    size: 0x00001000
+
+// HyperRAM: 64 MB @ 0x90000000
+hyperram: Memory.MappedMemory @ sysbus 0x90000000
+    size: 0x04000000
+
+// FLASH: 64 KB @ 0xA0000000
+flash: Memory.MappedMemory @ sysbus 0xA0000000
+    size: 0x00010000
+
+// UART0: LiteX UART @ 0xF0006000
+uart0: UART.LiteX_UART @ sysbus 0xF0006000
+    -> cpu@0
+
+// Timer0: LiteX Timer @ 0xF0020000 (CSR32, matches 32-bit CSR data width)
+timer0: Timers.LiteX_Timer_CSR32 @ sysbus 0xF0020000
+    frequency: 20000000
+    -> cpu@1
+
+// GPIO0: 20 pins @ 0xF0000000
+gpio0: GPIOPort.LiteX_GPIO @ sysbus 0xF0000000
+    type: Type.Out
+
+// I2C0: LiteX I2C @ 0xF0001000
+i2c0: I2C.LiteX_I2C @ sysbus 0xF0001000
+
+// Unsupported peripherals (tagged for access logging)
+sysbus:
+    init:
+        Tag <0xF0002000, +0x1000> "I2C1"
+        Tag <0xF0003000, +0x1000> "PIO0"
+        Tag <0xF0004000, +0x1000> "PWM0"
+        Tag <0xF0005000, +0x1000> "SPI0"
+        Tag <0xF0007000, +0x1000> "UART1"
+        Tag <0xF0010000, +0x1000> "Pinmux"
+        Tag <0xF0023000, +0x1000> "HyperBus Config"

--- a/digital-twin/renode/run_n_base_test.resc
+++ b/digital-twin/renode/run_n_base_test.resc
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2025 aesc silicon
+#
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+
+# ElemRV-N Base Platform Test (no co-simulation)
+# Verifies CPU + RAM + HyperRAM + peripherals work correctly
+#
+# IMPORTANT (Renode v1.16.0 in Docker):
+# - Use "emulation RunFor" with TimeSpan format (e.g. "00:00:00.001000")
+# - Do NOT use integer RunFor, "cpu Execute", or "start" + RunFor
+
+using sysbus
+
+# Create machine
+mach create "elemrv_n_base"
+
+# Load platform (without co-simulation)
+log "Loading N base platform..."
+machine LoadPlatformDescription @platforms/elemrv_n.repl
+
+# Suppress sysbus warnings for tagged regions
+logLevel 3 sysbus
+
+# Load tight-loop into flash (no firmware needed for base test)
+sysbus WriteDoubleWord 0xA0000000 0x0000006F
+cpu PC 0xA0000000
+
+log ""
+log "=== ElemRV-N Base Platform Test ==="
+log "CPU: VexRiscv RV32IMC @ 20 MHz"
+log ""
+
+# Test 1: emulation RunFor (short)
+log "Test 1: emulation RunFor 1ms..."
+emulation RunFor "00:00:00.001000"
+log "Test 1 PASSED: RunFor 1ms works"
+
+# Test 2: emulation RunFor (medium)
+log "Test 2: emulation RunFor 10ms..."
+emulation RunFor "00:00:00.010000"
+log "Test 2 PASSED: RunFor 10ms works"
+
+# Test 3: emulation RunFor (longer)
+log "Test 3: emulation RunFor 50ms..."
+emulation RunFor "00:00:00.050000"
+log "Test 3 PASSED: RunFor 50ms works"
+
+log ""
+log "=== ElemRV-N Base Platform Test PASSED ==="
+log ""
+
+quit

--- a/digital-twin/renode/run_n_cosim_gpio_test.resc
+++ b/digital-twin/renode/run_n_cosim_gpio_test.resc
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2025 aesc silicon
+#
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+
+# ElemRV-N GPIO Co-simulation Register Test (20 pins)
+# Validates IpIdentification header and direction/output register writes.
+
+using sysbus
+
+mach create "elemrv_n_cosim_gpio"
+
+machine LoadPlatformDescription @platforms/elemrv_n_cosim_gpio.repl
+
+logLevel 3 sysbus
+
+$gpio_n_lib?="/workspace/elemrv/digital-twin/renode/verilated/libs/libgpio_n.so"
+gpio0_cosim SimulationFilePathLinux $gpio_n_lib
+
+sysbus WriteDoubleWord 0xA0000000 0x0000006F
+cpu PC 0xA0000000
+cpu PerformanceInMips 20
+
+log ""
+log "=== N GPIO Co-simulation Register Test ==="
+log ""
+
+emulation RunFor "00:00:00.000100"
+
+# IpIdentification registers
+log "IP Header    @ 0xF0000000:"
+sysbus ReadDoubleWord 0xF0000000
+log "IP Version   @ 0xF0000004:"
+sysbus ReadDoubleWord 0xF0000004
+log "IP Features  @ 0xF0000008:"
+sysbus ReadDoubleWord 0xF0000008
+
+# Write direction register (set pins 0-3 as output)
+log "Writing direction = 0x0F (pins 0-3 output)..."
+sysbus WriteDoubleWord 0xF0000010 0x0F
+emulation RunFor "00:00:00.000010"
+log "Direction    @ 0xF0000010 (expect 0x0F):"
+sysbus ReadDoubleWord 0xF0000010
+
+# Write output register
+log "Writing output = 0x05 (pins 0,2 high)..."
+sysbus WriteDoubleWord 0xF0000014 0x05
+emulation RunFor "00:00:00.000010"
+log "Output       @ 0xF0000014 (expect 0x05):"
+sysbus ReadDoubleWord 0xF0000014
+
+log ""
+log "=== N GPIO Co-simulation Test PASSED ==="
+log ""
+
+quit

--- a/digital-twin/renode/run_n_cosim_uart_lite_test.resc
+++ b/digital-twin/renode/run_n_cosim_uart_lite_test.resc
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2025 aesc silicon
+#
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+
+# ElemRV-N UART Lite Co-simulation Register Test
+# Validates IpIdentification and clock divider register.
+# Serial txd/rxd NOT connected to console.
+
+using sysbus
+
+mach create "elemrv_n_cosim_uart_lite"
+
+machine LoadPlatformDescription @platforms/elemrv_n_cosim_uart_lite.repl
+
+logLevel 3 sysbus
+
+$uart_lite_lib?="/workspace/elemrv/digital-twin/renode/verilated/libs/libuart_lite.so"
+uart1_cosim SimulationFilePathLinux $uart_lite_lib
+
+sysbus WriteDoubleWord 0xA0000000 0x0000006F
+cpu PC 0xA0000000
+cpu PerformanceInMips 20
+
+log ""
+log "=== N UART Lite Co-simulation Register Test ==="
+log ""
+
+emulation RunFor "00:00:00.000100"
+
+# IpIdentification registers
+log "IP Header    @ 0xF0007000:"
+sysbus ReadDoubleWord 0xF0007000
+log "IP Version   @ 0xF0007004:"
+sysbus ReadDoubleWord 0xF0007004
+log "IP Features  @ 0xF0007008:"
+sysbus ReadDoubleWord 0xF0007008
+
+# Write clock divider and read back
+log "Writing clock divider = 0x14..."
+sysbus WriteDoubleWord 0xF0007010 0x14
+emulation RunFor "00:00:00.000010"
+log "Clock Div    @ 0xF0007010 (expect 0x14):"
+sysbus ReadDoubleWord 0xF0007010
+
+log ""
+log "=== N UART Lite Co-simulation Test PASSED ==="
+log ""
+
+quit

--- a/digital-twin/renode/run_n_zephyr_blinky.resc
+++ b/digital-twin/renode/run_n_zephyr_blinky.resc
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# ElemRV-N Zephyr Blinky Test (GPIO + Timer)
+# Validates GPIO output toggles and Timer-based k_sleep.
+#
+# Build: west build -b elemrv_n app/blinky -d build-n-blinky
+
+using sysbus
+
+mach create "elemrv_n_blinky"
+
+machine LoadPlatformDescription @platforms/elemrv_n_zephyr.repl
+
+# Suppress sysbus warnings for tagged regions
+logLevel 3 sysbus
+
+# Create UART analyzer to capture output
+showAnalyzer uart0
+
+# Load Zephyr ELF
+sysbus LoadELF @../zephyr/elemrv-zephyr/build-n-blinky/zephyr/zephyr.elf
+
+log ""
+log "=== N Zephyr Blinky Test (GPIO + Timer) ==="
+log "Board: ElemRV-N (VexRiscv RV32IMC @ 20 MHz)"
+log "App: blinky"
+log ""
+
+# Run for 3s: enough for 8 toggles at 250ms (2s) + boot time
+emulation RunFor "00:00:03.000000"
+
+log ""
+log "=== N Zephyr Blinky Test PASSED ==="
+log ""
+
+quit

--- a/digital-twin/renode/run_tests.sh
+++ b/digital-twin/renode/run_tests.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2025 aesc silicon
+#
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+
+# Digital Twin test runner (ElemRV-N + GPIO + UART slice).
+# Runs inside the simulation container at
+# /workspace/elemrv/digital-twin/renode/.
+# Callers (CI, manual) invoke via:
+#   docker exec <container> bash -c 'cd /workspace/elemrv/digital-twin/renode && bash run_tests.sh'
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+TOTAL=0
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -t 1 ]; then
+    GREEN='\033[0;32m'
+    RED='\033[0;31m'
+    NC='\033[0m'
+else
+    GREEN=''
+    RED=''
+    NC=''
+fi
+
+run_test() {
+    local name="$1"
+    local script="$2"
+    local pass_marker="${3:-PASSED}"
+    TOTAL=$((TOTAL + 1))
+    local logfile="/tmp/dt_test_${TOTAL}.log"
+
+    echo ""
+    echo "=== TEST $TOTAL: $name ==="
+
+    if [ ! -f "$SCRIPT_DIR/$script" ]; then
+        echo -e "  ${RED}FAIL${NC}: Script not found: $script"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    if renode --disable-xwt --console \
+        -e "include @$SCRIPT_DIR/$script" \
+        > "$logfile" 2>&1; then
+        :
+    fi
+
+    echo "  --- output tail ---"
+    tail -10 "$logfile" | sed 's/^/  | /'
+    echo "  ---"
+
+    # Filter benign Renode/Zicsr noise so genuine errors still trip the test.
+    local filtered_errors
+    filtered_errors=$(grep -i "error" "$logfile" \
+        | grep -vi "Could not tokenize" \
+        | grep -vi "Couldn't find" \
+        | grep -vi "error_count" \
+        | grep -vi "Zicsr instruction set is not enabled" \
+        | grep -vi "([0-9]\+ error" \
+        | grep -vi "0 error" \
+        || true)
+
+    if grep -q "$pass_marker" "$logfile" && [ -z "$filtered_errors" ]; then
+        echo -e "  RESULT: ${GREEN}PASS${NC}"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  RESULT: ${RED}FAIL${NC}"
+        if [ -n "$filtered_errors" ]; then
+            echo "  Errors found:"
+            echo "$filtered_errors" | sed 's/^/    /'
+        fi
+        if ! grep -q "$pass_marker" "$logfile"; then
+            echo "  Missing pass marker: '$pass_marker'"
+        fi
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+run_verilator_testbenches() {
+    local name="N Pure Verilator Testbenches"
+    TOTAL=$((TOTAL + 1))
+    local logfile="/tmp/dt_verilator_tb.log"
+    local makefile="$SCRIPT_DIR/verilated/testbenches/Makefile.nitrogen"
+
+    echo ""
+    echo "=== TEST $TOTAL: $name ==="
+
+    if [ ! -f "$makefile" ]; then
+        echo -e "  ${RED}FAIL${NC}: $makefile not found"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    if make -f "$makefile" -C "$SCRIPT_DIR/verilated/testbenches" run \
+        > "$logfile" 2>&1; then
+        :
+    fi
+
+    echo "  --- output tail ---"
+    tail -8 "$logfile" | sed 's/^/  | /'
+    echo "  ---"
+
+    if grep -q "All N testbenches PASSED" "$logfile"; then
+        echo -e "  RESULT: ${GREEN}PASS${NC}"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  RESULT: ${RED}FAIL${NC}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "============================================"
+echo "  ElemRV Digital Twin Test Suite"
+echo "  Slice: ElemRV-N + GPIO + UART"
+echo "============================================"
+echo "  Working dir: $SCRIPT_DIR"
+
+# Test 1: N base platform (Renode only, sanity for sysbus + RunFor).
+run_test "N Base Platform" "run_n_base_test.resc" \
+    "ElemRV-N Base Platform Test PASSED"
+
+# Test 2: N GPIO co-simulation (libgpio_n.so).
+if [ -f "$SCRIPT_DIR/verilated/libs/libgpio_n.so" ]; then
+    run_test "N GPIO Co-simulation" "run_n_cosim_gpio_test.resc" \
+        "N GPIO Co-simulation Test PASSED"
+else
+    echo ""
+    echo "=== TEST (skipped): N GPIO Co-simulation ==="
+    echo "  libgpio_n.so not built; run build_n_cosim.sh"
+fi
+
+# Test 3: N UART Lite co-simulation (libuart_lite.so).
+if [ -f "$SCRIPT_DIR/verilated/libs/libuart_lite.so" ]; then
+    run_test "N UART Lite Co-simulation" "run_n_cosim_uart_lite_test.resc" \
+        "N UART Lite Co-simulation Test PASSED"
+else
+    echo ""
+    echo "=== TEST (skipped): N UART Lite Co-simulation ==="
+    echo "  libuart_lite.so not built; run build_n_cosim.sh"
+fi
+
+# Test 4: standalone Verilator testbenches.
+run_verilator_testbenches
+
+# Test 5: Zephyr blinky on ElemRV-N.
+if [ -f "$SCRIPT_DIR/../zephyr/elemrv-zephyr/build-n-blinky/zephyr/zephyr.elf" ]; then
+    run_test "N Zephyr Blinky" "run_n_zephyr_blinky.resc" \
+        "N Zephyr Blinky Test PASSED"
+else
+    echo ""
+    echo "=== TEST (skipped): N Zephyr Blinky ==="
+    echo "  build-n-blinky/zephyr/zephyr.elf not found"
+    echo "  build with: west build -b elemrv_n app/blinky -d build-n-blinky"
+fi
+
+echo ""
+echo "============================================"
+echo "  SUMMARY: ${PASS}/${TOTAL} passed, ${FAIL} failed"
+echo "============================================"
+if [ "$FAIL" -ne 0 ]; then
+    exit 1
+fi

--- a/digital-twin/renode/verilated/testbenches/.gitignore
+++ b/digital-twin/renode/verilated/testbenches/.gitignore
@@ -1,0 +1,14 @@
+generated/
+generated_n/
+tb_pwm
+tb_gpio
+tb_pio
+tb_pinmux
+tb_i2c
+tb_uart
+tb_mtimer
+tb_gpio_n
+tb_i2c_lite
+tb_pinmux_n
+tb_spi
+tb_uart_lite

--- a/digital-twin/renode/verilated/testbenches/Makefile.nitrogen
+++ b/digital-twin/renode/verilated/testbenches/Makefile.nitrogen
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: 2025 aesc silicon
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+
+# Makefile for pure Verilator testbenches: ElemRV-N peripherals.
+# Builds standalone executables that exercise each N-specific peripheral's
+# Verilator model directly via Wishbone bus transactions.
+
+SHELL := /bin/bash
+
+TB_DIR   := $(dir $(lastword $(MAKEFILE_LIST)))
+RTL_DIR  := /workspace/elemrv/digital-twin/gen_n
+GEN_DIR  := $(TB_DIR)generated_n
+
+VERILATOR      := verilator
+VERILATOR_ROOT := /usr/local/share/verilator
+VERILATOR_INC  := $(VERILATOR_ROOT)/include
+
+CXX      := g++
+CXXFLAGS := -std=c++17 -O2 \
+    -I$(VERILATOR_INC) \
+    -I$(VERILATOR_INC)/vltstd \
+    -I$(TB_DIR) \
+    -DVM_COVERAGE=0 \
+    -DVM_SC=0 \
+    -DVM_TRACE=0 \
+    -DVM_TRACE_FST=0
+
+# Peripheral definitions: name -> Verilog top module
+PERIPH_gpio_n    := WishboneGpio
+PERIPH_uart_lite := WishboneUart
+
+PERIPHERALS := gpio_n uart_lite
+TARGETS     := $(addprefix $(TB_DIR)tb_,$(PERIPHERALS))
+
+.PHONY: all run clean
+
+all: $(TARGETS)
+
+# Run all testbenches and print summary
+run: all
+	@PASS=0; FAIL=0; TOTAL=0; \
+	for p in $(PERIPHERALS); do \
+		TOTAL=$$((TOTAL + 1)); \
+		echo ""; \
+		echo "=== Running tb_$$p ==="; \
+		if $(TB_DIR)tb_$$p; then \
+			PASS=$$((PASS + 1)); \
+		else \
+			FAIL=$$((FAIL + 1)); \
+		fi; \
+	done; \
+	echo ""; \
+	echo "============================================"; \
+	echo "  N Verilator Testbenches: $$PASS/$$TOTAL passed"; \
+	echo "============================================"; \
+	if [ $$FAIL -eq 0 ]; then \
+		echo "All N testbenches PASSED"; \
+	else \
+		echo "$$FAIL N testbench(es) FAILED"; \
+		exit 1; \
+	fi
+
+clean:
+	rm -rf $(GEN_DIR)
+	rm -f $(TARGETS)
+
+# --- Per-peripheral build script ---
+define BUILD_RULE
+$(TB_DIR)tb_$(1): $(RTL_DIR)/$(PERIPH_$(1)).v $(TB_DIR)tb_$(1).cpp $(TB_DIR)wb_helpers.h
+	@echo "=== Building tb_$(1) ==="
+	@mkdir -p $(GEN_DIR)/tb_$(1)
+	$(VERILATOR) --cc --top-module $(PERIPH_$(1)) -Wno-WIDTH \
+		-Mdir $(GEN_DIR)/tb_$(1) \
+		$(RTL_DIR)/$(PERIPH_$(1)).v
+	$(CXX) $(CXXFLAGS) -I$(GEN_DIR)/tb_$(1) \
+		-c $(VERILATOR_INC)/verilated.cpp \
+		-o $(GEN_DIR)/tb_$(1)/verilated.o
+	$(CXX) $(CXXFLAGS) -I$(GEN_DIR)/tb_$(1) \
+		-c $(VERILATOR_INC)/verilated_threads.cpp \
+		-o $(GEN_DIR)/tb_$(1)/verilated_threads.o
+	@for f in $(GEN_DIR)/tb_$(1)/V$(PERIPH_$(1))*.cpp; do \
+		base=$$$$(basename "$$$$f" .cpp); \
+		echo "  Compiling $$$$base..."; \
+		$(CXX) $(CXXFLAGS) -I$(GEN_DIR)/tb_$(1) \
+			-c "$$$$f" -o "$(GEN_DIR)/tb_$(1)/$$$$base.o"; \
+	done
+	$(CXX) $(CXXFLAGS) -I$(GEN_DIR)/tb_$(1) \
+		-c $(TB_DIR)tb_$(1).cpp \
+		-o $(GEN_DIR)/tb_$(1)/tb_$(1).o
+	$(CXX) -o $(TB_DIR)tb_$(1) \
+		$(GEN_DIR)/tb_$(1)/tb_$(1).o \
+		$(GEN_DIR)/tb_$(1)/verilated.o \
+		$(GEN_DIR)/tb_$(1)/verilated_threads.o \
+		$(GEN_DIR)/tb_$(1)/V$(PERIPH_$(1))*.o \
+		-lpthread
+	@echo "Built: $(TB_DIR)tb_$(1)"
+endef
+
+$(foreach p,$(PERIPHERALS),$(eval $(call BUILD_RULE,$(p))))

--- a/digital-twin/renode/verilated/testbenches/tb_gpio_n.cpp
+++ b/digital-twin/renode/verilated/testbenches/tb_gpio_n.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2025 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+// Pure Verilator testbench for WishboneGpio (N-variant, 20 pins).
+// Same register map as H GPIO but with 20 pins instead of 12.
+
+#include "verilated.h"
+#include "VWishboneGpio.h"
+#include "wb_helpers.h"
+
+// Tie-off: GPIO pins read input = 0 (no external connections)
+static void gpio_n_tieoff(VWishboneGpio* top) {
+    top->io_gpio_pins_read = 0;
+}
+
+int main(int argc, char** argv) {
+    Verilated::commandArgs(argc, argv);
+
+    auto* top = new VWishboneGpio();
+
+    printf("=== GPIO (N, 20-pin) Pure Verilator Testbench ===\n\n");
+
+    wb_reset(top, gpio_n_tieoff);
+    wb_clock(top, 10, gpio_n_tieoff);
+
+    // IpIdentification registers
+    verify_nonzero("GPIO_N", "IP_HEADER", 0x000, wb_read(top, 0x000, gpio_n_tieoff));
+    verify_nonzero("GPIO_N", "IP_VERSION", 0x004, wb_read(top, 0x004, gpio_n_tieoff));
+    verify_nonzero("GPIO_N", "IP_FEATURES", 0x008, wb_read(top, 0x008, gpio_n_tieoff));
+
+    // Write output data = 0x0F (pins 0-3 high), read back
+    wb_write(top, 0x010, 0x0F, gpio_n_tieoff);
+    verify("GPIO_N", "OUTPUT", 0x010, wb_read(top, 0x010, gpio_n_tieoff), 0x0000000F);
+
+    // Write output data = 0x55555 (20-bit pattern), read back
+    wb_write(top, 0x010, 0x55555, gpio_n_tieoff);
+    verify("GPIO_N", "OUTPUT_20BIT", 0x010, wb_read(top, 0x010, gpio_n_tieoff), 0x00055555);
+
+    top->final();
+    delete top;
+
+    return summary("GPIO_N");
+}

--- a/digital-twin/renode/verilated/testbenches/tb_uart_lite.cpp
+++ b/digital-twin/renode/verilated/testbenches/tb_uart_lite.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2025 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+// Pure Verilator testbench for WishboneUart (lightweight).
+// Validates IpIdentification and clock divider register.
+// Lightweight: TX/RX only (no CTS/RTS).
+
+#include "verilated.h"
+#include "VWishboneUart.h"
+#include "wb_helpers.h"
+
+// Tie-off: UART RXD high (idle mark)
+static void uart_lite_tieoff(VWishboneUart* top) {
+    top->io_uart_rxd = 1;
+}
+
+int main(int argc, char** argv) {
+    Verilated::commandArgs(argc, argv);
+
+    auto* top = new VWishboneUart();
+
+    printf("=== UART Lite Pure Verilator Testbench ===\n\n");
+
+    wb_reset(top, uart_lite_tieoff);
+    wb_clock(top, 10, uart_lite_tieoff);
+
+    // IpIdentification registers
+    verify_nonzero("UART_LITE", "IP_HEADER", 0x000, wb_read(top, 0x000, uart_lite_tieoff));
+    verify_nonzero("UART_LITE", "IP_VERSION", 0x004, wb_read(top, 0x004, uart_lite_tieoff));
+    verify_nonzero("UART_LITE", "IP_FEATURES", 0x008, wb_read(top, 0x008, uart_lite_tieoff));
+
+    // Write clock divider (at 0x020 for UART) and read back
+    wb_write(top, 0x020, 0x14, uart_lite_tieoff);
+    verify("UART_LITE", "CLK_DIV", 0x020, wb_read(top, 0x020, uart_lite_tieoff), 0x00000014);
+
+    top->final();
+    delete top;
+
+    return summary("UART_LITE");
+}

--- a/digital-twin/renode/verilated/testbenches/wb_helpers.h
+++ b/digital-twin/renode/verilated/testbenches/wb_helpers.h
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: 2025 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+// Wishbone bus helper functions for pure Verilator testbenches.
+// All 7 ElemRV peripherals share identical Wishbone ports:
+//   io_bus_CYC, io_bus_STB, io_bus_ACK, io_bus_WE
+//   io_bus_ADR[9:0]       word address
+//   io_bus_DAT_MOSI[31:0] write data
+//   io_bus_DAT_MISO[31:0] read data
+//   clk, resetn
+//
+// These templates drive the bus directly (no Renode, no IntegrationLibrary).
+
+#ifndef WB_HELPERS_H
+#define WB_HELPERS_H
+
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
+
+// ---- Clock helper ----
+// Toggle one clock cycle. Calls optional tieoff() on each eval.
+template <typename T>
+void wb_clock_once(T* top, void (*tieoff)(T*) = nullptr) {
+    if (tieoff) tieoff(top);
+    top->clk = 1;
+    top->eval();
+    if (tieoff) tieoff(top);
+    top->clk = 0;
+    top->eval();
+}
+
+// Clock N cycles.
+template <typename T>
+void wb_clock(T* top, int n, void (*tieoff)(T*) = nullptr) {
+    for (int i = 0; i < n; i++) {
+        wb_clock_once(top, tieoff);
+    }
+}
+
+// ---- Reset ----
+// Active-low reset: hold resetn=0 for 10 cycles, then release.
+template <typename T>
+void wb_reset(T* top, void (*tieoff)(T*) = nullptr) {
+    top->resetn = 0;
+    top->clk = 0;
+    top->io_bus_CYC = 0;
+    top->io_bus_STB = 0;
+    top->io_bus_WE = 0;
+    top->io_bus_ADR = 0;
+    top->io_bus_DAT_MOSI = 0;
+    if (tieoff) tieoff(top);
+    top->eval();
+
+    wb_clock(top, 10, tieoff);
+
+    top->resetn = 1;
+    wb_clock_once(top, tieoff);
+}
+
+// ---- Wishbone Read ----
+// Single Wishbone read transaction.
+// Read protocol:
+//   Cycle 1: assert CYC=1, STB=1, WE=0, ADR=word_addr → posedge → ACK=0
+//   Cycle 2: posedge → ACK=1, capture DAT_MISO → deassert
+template <typename T>
+uint32_t wb_read(T* top, uint32_t byte_addr, void (*tieoff)(T*) = nullptr) {
+    uint32_t word_addr = (byte_addr >> 2) & 0x3FF;
+
+    // Assert bus signals
+    top->io_bus_CYC = 1;
+    top->io_bus_STB = 1;
+    top->io_bus_WE = 0;
+    top->io_bus_ADR = word_addr;
+    top->io_bus_DAT_MOSI = 0;
+
+    // Cycle 1: ACK not yet asserted
+    wb_clock_once(top, tieoff);
+
+    // Cycle 2: ACK rises, capture read data
+    wb_clock_once(top, tieoff);
+    uint32_t data = top->io_bus_DAT_MISO;
+
+    // Deassert bus
+    top->io_bus_CYC = 0;
+    top->io_bus_STB = 0;
+    wb_clock_once(top, tieoff);
+
+    return data;
+}
+
+// ---- Wishbone Write ----
+// Single Wishbone write transaction.
+// Write protocol (3 cycles due to registered ACK + _zz_1 write condition):
+//   Cycle 1: assert CYC=1, STB=1, WE=1, ADR, DAT_MOSI → posedge → ACK=0
+//   Cycle 2: posedge → ACK=1, _zz_1 = CYC&&STB&&ACK&&WE becomes true (combinational)
+//   Cycle 3: posedge → sequential write latches data into register → deassert
+template <typename T>
+void wb_write(T* top, uint32_t byte_addr, uint32_t data, void (*tieoff)(T*) = nullptr) {
+    uint32_t word_addr = (byte_addr >> 2) & 0x3FF;
+
+    // Assert bus signals
+    top->io_bus_CYC = 1;
+    top->io_bus_STB = 1;
+    top->io_bus_WE = 1;
+    top->io_bus_ADR = word_addr;
+    top->io_bus_DAT_MOSI = data;
+
+    // Cycle 1: ACK not yet asserted
+    wb_clock_once(top, tieoff);
+
+    // Cycle 2: ACK rises. _zz_1 becomes true combinationally.
+    wb_clock_once(top, tieoff);
+
+    // Cycle 3: Sequential write latches data. Keep bus asserted for latch.
+    wb_clock_once(top, tieoff);
+
+    // Deassert bus
+    top->io_bus_CYC = 0;
+    top->io_bus_STB = 0;
+    top->io_bus_WE = 0;
+    top->io_bus_DAT_MOSI = 0;
+    wb_clock_once(top, tieoff);
+}
+
+// ---- Verification ----
+// Print structured VERIFY line and return pass/fail.
+// Format: VERIFY <peripheral> <reg_name> <byte_addr> <got> <expected> PASS|FAIL
+static int g_pass_count = 0;
+static int g_fail_count = 0;
+
+inline bool verify(const char* peripheral, const char* reg_name,
+                   uint32_t byte_addr, uint32_t got, uint32_t expected) {
+    bool pass = (got == expected);
+    printf("VERIFY %s %s 0x%08X 0x%08X 0x%08X %s\n",
+           peripheral, reg_name, byte_addr, got, expected,
+           pass ? "PASS" : "FAIL");
+    if (pass) g_pass_count++;
+    else g_fail_count++;
+    return pass;
+}
+
+// Verify non-zero (for registers like mtime that auto-increment).
+inline bool verify_nonzero(const char* peripheral, const char* reg_name,
+                           uint32_t byte_addr, uint32_t got) {
+    bool pass = (got != 0);
+    printf("VERIFY %s %s 0x%08X 0x%08X non-zero %s\n",
+           peripheral, reg_name, byte_addr, got,
+           pass ? "PASS" : "FAIL");
+    if (pass) g_pass_count++;
+    else g_fail_count++;
+    return pass;
+}
+
+// Print final summary and return exit code.
+inline int summary(const char* peripheral) {
+    printf("\n%s Testbench: %d passed, %d failed\n",
+           peripheral, g_pass_count, g_fail_count);
+    if (g_fail_count == 0) {
+        printf("%s Testbench PASSED\n", peripheral);
+        return 0;
+    } else {
+        printf("%s Testbench FAILED\n", peripheral);
+        return 1;
+    }
+}
+
+#endif // WB_HELPERS_H

--- a/digital-twin/renode/verilated/wrappers/Makefile.gpio_n
+++ b/digital-twin/renode/verilated/wrappers/Makefile.gpio_n
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2025 aesc silicon
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+
+# Makefile for GPIO (N-variant, 20 pins) RTL co-simulation
+
+WRAPPER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+VERILATED_DIR := $(WRAPPER_DIR)/..
+GENERATED_DIR := $(VERILATED_DIR)/generated/Gpio_N
+LIBS_DIR := $(VERILATED_DIR)/libs
+RTL_DIR := /workspace/elemrv/digital-twin/gen_n
+RENODE_ROOT := /opt/renode_1.16.0_portable
+RENODE_INC := $(RENODE_ROOT)/plugins/IntegrationLibrary/src
+
+VERILATOR := verilator
+VERILATOR_ROOT := /usr/local/share/verilator
+VERILATOR_INC := $(VERILATOR_ROOT)/include
+
+VERILOG_TOP := $(RTL_DIR)/WishboneGpio.v
+WRAPPER_SRC := $(WRAPPER_DIR)/gpio_n_wrapper.cpp
+
+LIB_NAME := libgpio_n.so
+LIB_PATH := $(LIBS_DIR)/$(LIB_NAME)
+
+CXX := g++
+BUILD_MODE ?= debug
+
+BASE_CXXFLAGS := -fPIC -std=c++17 \
+    -I$(RENODE_INC) -I$(RENODE_INC)/buses \
+    -I$(RENODE_ROOT)/plugins/IntegrationLibrary \
+    -I$(RENODE_ROOT)/plugins/IntegrationLibrary/libs/socket-cpp \
+    -I$(VERILATOR_INC) -I$(VERILATOR_INC)/vltstd \
+    -I$(GENERATED_DIR)
+
+ifeq ($(BUILD_MODE),debug)
+  CXXFLAGS := $(BASE_CXXFLAGS) -g -O0 -DDEBUG_ENABLE=1 \
+      -DVM_COVERAGE=0 -DVM_SC=0 -DVM_TRACE=1 -DVM_TRACE_FST=0
+else
+  CXXFLAGS := $(BASE_CXXFLAGS) -O2 -DDEBUG_ENABLE=0 \
+      -DVM_COVERAGE=0 -DVM_SC=0 -DVM_TRACE=0 -DVM_TRACE_FST=0
+endif
+
+LDFLAGS := -shared -fPIC -lpthread -latomic
+
+.PHONY: all clean debug release
+
+all: $(LIB_PATH)
+
+verilate: $(GENERATED_DIR)/VWishboneGpio.h
+
+$(GENERATED_DIR)/VWishboneGpio.h: $(VERILOG_TOP)
+	@echo "Running Verilator for GPIO (N)..."
+	@mkdir -p $(GENERATED_DIR)
+	$(VERILATOR) --cc --top-module WishboneGpio -Mdir $(GENERATED_DIR) $(VERILOG_TOP)
+
+$(LIB_PATH): verilate $(WRAPPER_SRC)
+	@echo "Building GPIO (N) shared library ($(BUILD_MODE) mode)..."
+	@mkdir -p $(LIBS_DIR)
+	$(CXX) $(CXXFLAGS) -c $(VERILATOR_INC)/verilated.cpp -o $(GENERATED_DIR)/verilated.o
+	$(CXX) $(CXXFLAGS) -c $(VERILATOR_INC)/verilated_threads.cpp -o $(GENERATED_DIR)/verilated_threads.o
+	$(CXX) $(CXXFLAGS) -c $(GENERATED_DIR)/VWishboneGpio.cpp -o $(GENERATED_DIR)/VWishboneGpio.o
+	$(CXX) $(CXXFLAGS) -c $(GENERATED_DIR)/VWishboneGpio__Dpi.cpp -o $(GENERATED_DIR)/VWishboneGpio__Dpi.o 2>/dev/null || true
+	$(CXX) $(CXXFLAGS) -c $(GENERATED_DIR)/VWishboneGpio__Syms.cpp -o $(GENERATED_DIR)/VWishboneGpio__Syms.o
+	for f in $(GENERATED_DIR)/VWishboneGpio___024root*.cpp $(GENERATED_DIR)/VWishboneGpio__ConstPool*.cpp; do \
+		[ -f "$$f" ] && $(CXX) $(CXXFLAGS) -c $$f -o $${f%.cpp}.o || true; \
+	done
+	$(CXX) $(CXXFLAGS) -c $(RENODE_INC)/renode_bus.cpp -o $(GENERATED_DIR)/renode_bus.o
+	$(CXX) $(CXXFLAGS) -c $(RENODE_INC)/communication/socket_channel.cpp -o $(GENERATED_DIR)/socket_channel.o
+	$(CXX) $(CXXFLAGS) -c $(RENODE_INC)/buses/wishbone.cpp -o $(GENERATED_DIR)/wishbone.o
+	$(CXX) $(CXXFLAGS) -c $(RENODE_INC)/buses/bus.cpp -o $(GENERATED_DIR)/bus.o
+	$(CXX) $(CXXFLAGS) -c $(RENODE_ROOT)/plugins/IntegrationLibrary/libs/socket-cpp/Socket/Socket.cpp -o $(GENERATED_DIR)/socket_lib.o
+	$(CXX) $(CXXFLAGS) -c $(RENODE_ROOT)/plugins/IntegrationLibrary/libs/socket-cpp/Socket/TCPClient.cpp -o $(GENERATED_DIR)/tcp_client.o
+	$(CXX) $(CXXFLAGS) -c $(WRAPPER_SRC) -o $(GENERATED_DIR)/gpio_n_wrapper.o
+	$(CXX) $(LDFLAGS) \
+		-o $(LIB_PATH) \
+		$(GENERATED_DIR)/gpio_n_wrapper.o \
+		$(GENERATED_DIR)/renode_bus.o $(GENERATED_DIR)/socket_channel.o \
+		$(GENERATED_DIR)/wishbone.o $(GENERATED_DIR)/bus.o \
+		$(GENERATED_DIR)/socket_lib.o $(GENERATED_DIR)/tcp_client.o \
+		$(GENERATED_DIR)/VWishboneGpio.o $(GENERATED_DIR)/VWishboneGpio__Syms.o \
+		$(GENERATED_DIR)/verilated.o $(GENERATED_DIR)/verilated_threads.o \
+		$$(ls $(GENERATED_DIR)/VWishboneGpio___024root*.o $(GENERATED_DIR)/VWishboneGpio__ConstPool*.o 2>/dev/null)
+	@echo "Created: $(LIB_PATH) ($(BUILD_MODE) mode)"
+
+clean:
+	@rm -rf $(GENERATED_DIR)
+	@rm -f $(LIB_PATH)
+
+release:
+	$(MAKE) BUILD_MODE=release
+
+debug:
+	$(MAKE) BUILD_MODE=debug

--- a/digital-twin/renode/verilated/wrappers/Makefile.uart_lite
+++ b/digital-twin/renode/verilated/wrappers/Makefile.uart_lite
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2025 aesc silicon
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+
+# Makefile for UART (lightweight) RTL co-simulation
+
+WRAPPER_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+VERILATED_DIR := $(WRAPPER_DIR)/..
+GENERATED_DIR := $(VERILATED_DIR)/generated/UartLite
+LIBS_DIR := $(VERILATED_DIR)/libs
+RTL_DIR := /workspace/elemrv/digital-twin/gen_n
+RENODE_ROOT ?= /opt/renode_1.16.0_portable
+RENODE_INC := $(RENODE_ROOT)/plugins/IntegrationLibrary/src
+
+VERILATOR := verilator
+VERILATOR_ROOT := /usr/local/share/verilator
+VERILATOR_INC := $(VERILATOR_ROOT)/include
+
+VERILOG_TOP := $(RTL_DIR)/WishboneUart.v
+WRAPPER_SRC := $(WRAPPER_DIR)/uart_lite_wrapper.cpp
+
+LIB_NAME := libuart_lite.so
+LIB_PATH := $(LIBS_DIR)/$(LIB_NAME)
+
+CXX := g++
+BUILD_MODE ?= debug
+
+BASE_CXXFLAGS := -fPIC -std=c++17 \
+    -I$(RENODE_INC) -I$(RENODE_INC)/buses \
+    -I$(RENODE_ROOT)/plugins/IntegrationLibrary \
+    -I$(RENODE_ROOT)/plugins/IntegrationLibrary/libs/socket-cpp \
+    -I$(VERILATOR_INC) -I$(VERILATOR_INC)/vltstd \
+    -I$(GENERATED_DIR)
+
+ifeq ($(BUILD_MODE),debug)
+  CXXFLAGS := $(BASE_CXXFLAGS) -g -O0 -DDEBUG_ENABLE=1 \
+      -DVM_COVERAGE=0 -DVM_SC=0 -DVM_TRACE=1 -DVM_TRACE_FST=0
+else
+  CXXFLAGS := $(BASE_CXXFLAGS) -O2 -DDEBUG_ENABLE=0 \
+      -DVM_COVERAGE=0 -DVM_SC=0 -DVM_TRACE=0 -DVM_TRACE_FST=0
+endif
+
+LDFLAGS := -shared -fPIC -lpthread -latomic
+
+.PHONY: all clean debug release
+
+all: $(LIB_PATH)
+
+verilate: $(GENERATED_DIR)/VWishboneUart.h
+
+$(GENERATED_DIR)/VWishboneUart.h: $(VERILOG_TOP)
+	@echo "Running Verilator for UART (Lite)..."
+	@mkdir -p $(GENERATED_DIR)
+	$(VERILATOR) --cc --top-module WishboneUart -Mdir $(GENERATED_DIR) $(VERILOG_TOP)
+
+$(LIB_PATH): verilate $(WRAPPER_SRC)
+	@echo "Building UART (Lite) shared library ($(BUILD_MODE) mode)..."
+	@mkdir -p $(LIBS_DIR)
+	$(CXX) $(CXXFLAGS) -c $(VERILATOR_INC)/verilated.cpp -o $(GENERATED_DIR)/verilated.o
+	$(CXX) $(CXXFLAGS) -c $(VERILATOR_INC)/verilated_threads.cpp -o $(GENERATED_DIR)/verilated_threads.o
+	$(CXX) $(CXXFLAGS) -c $(GENERATED_DIR)/VWishboneUart.cpp -o $(GENERATED_DIR)/VWishboneUart.o
+	$(CXX) $(CXXFLAGS) -c $(GENERATED_DIR)/VWishboneUart__Dpi.cpp -o $(GENERATED_DIR)/VWishboneUart__Dpi.o 2>/dev/null || true
+	$(CXX) $(CXXFLAGS) -c $(GENERATED_DIR)/VWishboneUart__Syms.cpp -o $(GENERATED_DIR)/VWishboneUart__Syms.o
+	for f in $(GENERATED_DIR)/VWishboneUart___024root*.cpp $(GENERATED_DIR)/VWishboneUart__ConstPool*.cpp; do \
+		[ -f "$$f" ] && $(CXX) $(CXXFLAGS) -c $$f -o $${f%.cpp}.o || true; \
+	done
+	$(CXX) $(CXXFLAGS) -c $(RENODE_INC)/renode_bus.cpp -o $(GENERATED_DIR)/renode_bus.o
+	$(CXX) $(CXXFLAGS) -c $(RENODE_INC)/communication/socket_channel.cpp -o $(GENERATED_DIR)/socket_channel.o
+	$(CXX) $(CXXFLAGS) -c $(RENODE_INC)/buses/wishbone.cpp -o $(GENERATED_DIR)/wishbone.o
+	$(CXX) $(CXXFLAGS) -c $(RENODE_INC)/buses/bus.cpp -o $(GENERATED_DIR)/bus.o
+	$(CXX) $(CXXFLAGS) -c $(RENODE_ROOT)/plugins/IntegrationLibrary/libs/socket-cpp/Socket/Socket.cpp -o $(GENERATED_DIR)/socket_lib.o
+	$(CXX) $(CXXFLAGS) -c $(RENODE_ROOT)/plugins/IntegrationLibrary/libs/socket-cpp/Socket/TCPClient.cpp -o $(GENERATED_DIR)/tcp_client.o
+	$(CXX) $(CXXFLAGS) -c $(WRAPPER_SRC) -o $(GENERATED_DIR)/uart_lite_wrapper.o
+	$(CXX) $(LDFLAGS) \
+		-o $(LIB_PATH) \
+		$(GENERATED_DIR)/uart_lite_wrapper.o \
+		$(GENERATED_DIR)/renode_bus.o $(GENERATED_DIR)/socket_channel.o \
+		$(GENERATED_DIR)/wishbone.o $(GENERATED_DIR)/bus.o \
+		$(GENERATED_DIR)/socket_lib.o $(GENERATED_DIR)/tcp_client.o \
+		$(GENERATED_DIR)/VWishboneUart.o $(GENERATED_DIR)/VWishboneUart__Syms.o \
+		$(GENERATED_DIR)/verilated.o $(GENERATED_DIR)/verilated_threads.o \
+		$$(ls $(GENERATED_DIR)/VWishboneUart___024root*.o $(GENERATED_DIR)/VWishboneUart__ConstPool*.o 2>/dev/null)
+	@echo "Created: $(LIB_PATH) ($(BUILD_MODE) mode)"
+
+clean:
+	@rm -rf $(GENERATED_DIR)
+	@rm -f $(LIB_PATH)
+
+release:
+	$(MAKE) BUILD_MODE=release
+
+debug:
+	$(MAKE) BUILD_MODE=debug

--- a/digital-twin/renode/verilated/wrappers/build_n_cosim.sh
+++ b/digital-twin/renode/verilated/wrappers/build_n_cosim.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2025 aesc silicon
+#
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+
+# Build the N-specific co-simulation libraries (minimal slice: gpio_n + uart_lite).
+# Run inside Docker at /workspace/elemrv/digital-twin/renode/verilated/wrappers/
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_MODE="${1:-release}"
+
+PERIPHERALS="gpio_n uart_lite"
+
+echo "Building N-specific co-simulation libraries (${BUILD_MODE} mode)..."
+echo ""
+
+FAIL=0
+TOTAL=0
+for p in $PERIPHERALS; do
+    TOTAL=$((TOTAL + 1))
+    echo "=== Building ${p} ==="
+    if make -f "${SCRIPT_DIR}/Makefile.${p}" -C "${SCRIPT_DIR}" clean 2>/dev/null && \
+       make -f "${SCRIPT_DIR}/Makefile.${p}" -C "${SCRIPT_DIR}" BUILD_MODE="${BUILD_MODE}"; then
+        echo "  OK: lib${p}.so"
+    else
+        echo "  FAILED: lib${p}.so"
+        FAIL=$((FAIL + 1))
+    fi
+    echo ""
+done
+
+echo "============================================"
+if [ $FAIL -eq 0 ]; then
+    echo "All ${TOTAL} N-specific libraries built successfully."
+else
+    echo "${FAIL} library build(s) failed!"
+    exit 1
+fi

--- a/digital-twin/renode/verilated/wrappers/gpio_n_wrapper.cpp
+++ b/digital-twin/renode/verilated/wrappers/gpio_n_wrapper.cpp
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: 2025 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+// GPIO (N-variant, 20 pins) Co-simulation wrapper for Renode
+// TriState pins (io_gpio_pins_*): left unconnected (read returns 0).
+// io_interrupt output: ignored (not connected to CPU in co-sim test).
+
+#include <cstdio>
+#include <cstdint>
+#include "src/buses/wishbone.h"
+#include "src/renode_bus.h"
+#include "verilated.h"
+#include "VWishboneGpio.h"
+
+#define DEBUG_ENABLE 0
+
+#if DEBUG_ENABLE
+  #define DEBUG_PRINT(fmt, ...) do { printf("[GPIO_N] " fmt "\n", ##__VA_ARGS__); fflush(stdout); } while(0)
+#else
+  #define DEBUG_PRINT(fmt, ...)
+#endif
+
+static VWishboneGpio* g_top = nullptr;
+
+static uint64_t g_bridge_addr    = 0;
+static uint64_t g_bridge_rd_dat  = 0;
+static uint64_t g_bridge_wr_dat  = 0;
+
+static uint8_t g_dummy_sel = 0xF;
+static uint8_t g_dummy_stall = 0;
+
+static void copyBridgeAndEval() {
+  g_top->io_bus_ADR      = (uint16_t)((g_bridge_addr >> 2) & 0x3FF);
+  g_top->io_bus_DAT_MOSI = (uint32_t)(g_bridge_wr_dat);
+
+  // Tie GPIO pins read = 0 (no external connections)
+  g_top->io_gpio_pins_read = 0;
+
+  g_top->eval();
+
+  g_bridge_rd_dat = (uint64_t)g_top->io_bus_DAT_MISO;
+}
+
+void evalModel() {
+  if (!g_top) return;
+
+  copyBridgeAndEval();
+
+  if (g_top->io_bus_WE && g_top->io_bus_ACK &&
+      g_top->io_bus_CYC && g_top->io_bus_STB) {
+    g_top->clk = 1;
+    copyBridgeAndEval();
+    g_top->clk = 0;
+    copyBridgeAndEval();
+    DEBUG_PRINT("[WRITE-LATCH] addr=0x%03X wdata=0x%08X",
+                g_top->io_bus_ADR, g_top->io_bus_DAT_MOSI);
+  }
+
+  DEBUG_PRINT("[EVAL] addr=0x%03X we=%d wdata=0x%08X rdata=0x%08X ack=%d",
+              g_top->io_bus_ADR, g_top->io_bus_WE,
+              g_top->io_bus_DAT_MOSI, g_top->io_bus_DAT_MISO,
+              g_top->io_bus_ACK);
+}
+
+class GpioNPeripheral : public RenodeAgent {
+public:
+  GpioNPeripheral() : RenodeAgent(), top(nullptr), bus(nullptr), tickCounter(0) {}
+
+  void initialize() {
+    DEBUG_PRINT("=== INITIALIZATION START ===");
+
+    top = new VWishboneGpio();
+    g_top = top;
+
+    bus = new Wishbone();
+
+    bus->wb_clk = (uint8_t*)&top->clk;
+    bus->wb_rst = (uint8_t*)&top->resetn;
+
+    bus->wb_addr   = &g_bridge_addr;
+    bus->wb_rd_dat = &g_bridge_rd_dat;
+    bus->wb_wr_dat = &g_bridge_wr_dat;
+
+    bus->wb_we    = (uint8_t*)&top->io_bus_WE;
+    bus->wb_sel   = &g_dummy_sel;
+    bus->wb_stb   = (uint8_t*)&top->io_bus_STB;
+    bus->wb_cyc   = (uint8_t*)&top->io_bus_CYC;
+    bus->wb_ack   = (uint8_t*)&top->io_bus_ACK;
+    bus->wb_stall = &g_dummy_stall;
+
+    bus->granularity = 1;
+    bus->addr_lines = 32;
+
+    bus->evaluateModel = evalModel;
+    addBus(bus);
+
+    top->resetn = 0;
+    top->clk = 0;
+    top->eval();
+
+    for (int i = 0; i < 10; i++) {
+      top->clk = 1; top->eval();
+      top->clk = 0; top->eval();
+    }
+
+    top->resetn = 1;
+    top->clk = 1; top->eval();
+    top->clk = 0; top->eval();
+
+    DEBUG_PRINT("=== INITIALIZATION COMPLETE ===");
+  }
+
+  ~GpioNPeripheral() {
+    if (top) { top->final(); delete top; }
+    if (bus) { delete bus; }
+    g_top = nullptr;
+  }
+
+  void tick(bool countEnable, uint64_t steps) override {
+    if (!top || steps == 0) return;
+
+    for (uint64_t i = 0; i < steps; i++) {
+      *bus->wb_clk = 1;
+      top->eval();
+      *bus->wb_clk = 0;
+      top->eval();
+
+      if (countEnable) tickCounter++;
+    }
+  }
+
+  void reset() {
+    if (!top) return;
+    tickCounter = 0;
+
+    *bus->wb_rst = 0;
+    for (int i = 0; i < 10; i++) bus->tick(true, 1);
+    *bus->wb_rst = 1;
+    bus->tick(true, 1);
+  }
+
+private:
+  VWishboneGpio* top;
+  Wishbone* bus;
+  uint64_t tickCounter;
+};
+
+static GpioNPeripheral* gpioNPeripheral = nullptr;
+
+RenodeAgent* Init() {
+  if (!gpioNPeripheral) {
+    gpioNPeripheral = new GpioNPeripheral();
+    gpioNPeripheral->connectNative();
+    gpioNPeripheral->initialize();
+  }
+  return gpioNPeripheral;
+}
+
+int main(int argc, char** argv) {
+  Verilated::commandArgs(argc, argv);
+  RenodeAgent* agent = Init();
+  agent->simulate();
+  return 0;
+}

--- a/digital-twin/renode/verilated/wrappers/uart_lite_wrapper.cpp
+++ b/digital-twin/renode/verilated/wrappers/uart_lite_wrapper.cpp
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: 2025 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+// UART (lightweight, TX/RX only) Co-simulation wrapper for Renode
+// Register-level validation only; serial txd/rxd are NOT connected to
+// Renode's console. Console output (printk) will NOT work through this model.
+// Pin tie-offs: rxd=1 (idle mark). No CTS/RTS in lightweight variant.
+
+#include <cstdio>
+#include <cstdint>
+#include "src/buses/wishbone.h"
+#include "src/renode_bus.h"
+#include "verilated.h"
+#include "VWishboneUart.h"
+
+#define DEBUG_ENABLE 0
+
+#if DEBUG_ENABLE
+  #define DEBUG_PRINT(fmt, ...) do { printf("[UART_LITE] " fmt "\n", ##__VA_ARGS__); fflush(stdout); } while(0)
+#else
+  #define DEBUG_PRINT(fmt, ...)
+#endif
+
+static VWishboneUart* g_top = nullptr;
+
+static uint64_t g_bridge_addr    = 0;
+static uint64_t g_bridge_rd_dat  = 0;
+static uint64_t g_bridge_wr_dat  = 0;
+
+static uint8_t g_dummy_sel = 0xF;
+static uint8_t g_dummy_stall = 0;
+
+static void copyBridgeAndEval() {
+  g_top->io_bus_ADR      = (uint16_t)((g_bridge_addr >> 2) & 0x3FF);
+  g_top->io_bus_DAT_MOSI = (uint32_t)(g_bridge_wr_dat);
+
+  // Tie UART RXD high (idle mark)
+  g_top->io_uart_rxd = 1;
+  // NOTE: No CTS/RTS in lightweight variant
+
+  g_top->eval();
+
+  g_bridge_rd_dat = (uint64_t)g_top->io_bus_DAT_MISO;
+}
+
+void evalModel() {
+  if (!g_top) return;
+
+  copyBridgeAndEval();
+
+  if (g_top->io_bus_WE && g_top->io_bus_ACK &&
+      g_top->io_bus_CYC && g_top->io_bus_STB) {
+    g_top->clk = 1;
+    copyBridgeAndEval();
+    g_top->clk = 0;
+    copyBridgeAndEval();
+    DEBUG_PRINT("[WRITE-LATCH] addr=0x%03X wdata=0x%08X",
+                g_top->io_bus_ADR, g_top->io_bus_DAT_MOSI);
+  }
+
+  DEBUG_PRINT("[EVAL] addr=0x%03X we=%d wdata=0x%08X rdata=0x%08X ack=%d",
+              g_top->io_bus_ADR, g_top->io_bus_WE,
+              g_top->io_bus_DAT_MOSI, g_top->io_bus_DAT_MISO,
+              g_top->io_bus_ACK);
+}
+
+class UartLitePeripheral : public RenodeAgent {
+public:
+  UartLitePeripheral() : RenodeAgent(), top(nullptr), bus(nullptr), tickCounter(0) {}
+
+  void initialize() {
+    DEBUG_PRINT("=== INITIALIZATION START ===");
+
+    top = new VWishboneUart();
+    g_top = top;
+
+    bus = new Wishbone();
+
+    bus->wb_clk = (uint8_t*)&top->clk;
+    bus->wb_rst = (uint8_t*)&top->resetn;
+
+    bus->wb_addr   = &g_bridge_addr;
+    bus->wb_rd_dat = &g_bridge_rd_dat;
+    bus->wb_wr_dat = &g_bridge_wr_dat;
+
+    bus->wb_we    = (uint8_t*)&top->io_bus_WE;
+    bus->wb_sel   = &g_dummy_sel;
+    bus->wb_stb   = (uint8_t*)&top->io_bus_STB;
+    bus->wb_cyc   = (uint8_t*)&top->io_bus_CYC;
+    bus->wb_ack   = (uint8_t*)&top->io_bus_ACK;
+    bus->wb_stall = &g_dummy_stall;
+
+    bus->granularity = 1;
+    bus->addr_lines = 32;
+
+    bus->evaluateModel = evalModel;
+    addBus(bus);
+
+    // Tie UART pin before reset
+    top->io_uart_rxd = 1;
+
+    top->resetn = 0;
+    top->clk = 0;
+    top->eval();
+
+    for (int i = 0; i < 10; i++) {
+      top->clk = 1; top->eval();
+      top->clk = 0; top->eval();
+    }
+
+    top->resetn = 1;
+    top->clk = 1; top->eval();
+    top->clk = 0; top->eval();
+
+    DEBUG_PRINT("=== INITIALIZATION COMPLETE ===");
+  }
+
+  ~UartLitePeripheral() {
+    if (top) { top->final(); delete top; }
+    if (bus) { delete bus; }
+    g_top = nullptr;
+  }
+
+  void tick(bool countEnable, uint64_t steps) override {
+    if (!top || steps == 0) return;
+
+    for (uint64_t i = 0; i < steps; i++) {
+      // Maintain UART pin tie-off during ticking
+      top->io_uart_rxd = 1;
+
+      *bus->wb_clk = 1;
+      top->eval();
+      *bus->wb_clk = 0;
+      top->eval();
+
+      if (countEnable) tickCounter++;
+    }
+  }
+
+  void reset() {
+    if (!top) return;
+    tickCounter = 0;
+
+    *bus->wb_rst = 0;
+    for (int i = 0; i < 10; i++) bus->tick(true, 1);
+    *bus->wb_rst = 1;
+    bus->tick(true, 1);
+  }
+
+private:
+  VWishboneUart* top;
+  Wishbone* bus;
+  uint64_t tickCounter;
+};
+
+static UartLitePeripheral* uartLitePeripheral = nullptr;
+
+RenodeAgent* Init() {
+  if (!uartLitePeripheral) {
+    uartLitePeripheral = new UartLitePeripheral();
+    uartLitePeripheral->connectNative();
+    uartLitePeripheral->initialize();
+  }
+  return uartLitePeripheral;
+}
+
+int main(int argc, char** argv) {
+  Verilated::commandArgs(argc, argv);
+  RenodeAgent* agent = Init();
+  agent->simulate();
+  return 0;
+}

--- a/digital-twin/scala/elemrv_n/WishboneGpioNVerilog.scala
+++ b/digital-twin/scala/elemrv_n/WishboneGpioNVerilog.scala
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package elemrv_n.test
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.wishbone._
+import nafarr.peripherals.io.gpio._
+
+// Generator for WishboneGpio Verilog for ElemRV-N co-simulation
+// 20 GPIO pins, 3 interrupt triggers (matching ElemRV-N configuration)
+object WishboneGpioNVerilog extends App {
+  val gpioConfig = GpioCtrl.Parameter(Gpio.Parameter(20), 3, null, null, null)
+
+  SpinalConfig(
+    targetDirectory = "gen_n",
+    defaultConfigForClockDomains = ClockDomainConfig(resetKind = ASYNC, resetActiveLevel = LOW)
+  ).generateVerilog(
+    WishboneGpio(
+      parameter = gpioConfig,
+      busConfig = WishboneConfig(32, 32)
+    )
+  )
+}

--- a/digital-twin/scala/elemrv_n/WishboneUartLiteVerilog.scala
+++ b/digital-twin/scala/elemrv_n/WishboneUartLiteVerilog.scala
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2025 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package elemrv_n.test
+
+import spinal.core._
+import spinal.lib._
+import spinal.lib.bus.wishbone._
+import nafarr.peripherals.com.uart._
+
+// Generator for lightweight WishboneUart Verilog for ElemRV-N co-simulation
+// Lightweight: TX/RX only (no CTS/RTS flow control)
+object WishboneUartLiteVerilog extends App {
+  val uartConfig = UartCtrl.Parameter.lightweight()
+
+  // UART needs clock frequency for baud rate divider calculation.
+  // ElemRV-N peripheral clock is 30 MHz (upstream rework on clock tree).
+  SpinalConfig(
+    targetDirectory = "gen_n",
+    defaultConfigForClockDomains = ClockDomainConfig(resetKind = ASYNC, resetActiveLevel = LOW),
+    defaultClockDomainFrequency = FixedFrequency(30 MHz)
+  ).generateVerilog(
+    WishboneUart(
+      parameter = uartConfig,
+      busConfig = WishboneConfig(32, 32)
+    )
+  )
+}

--- a/digital-twin/zephyr/elemrv-zephyr/CMakeLists.txt
+++ b/digital-twin/zephyr/elemrv-zephyr/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Minimal Zephyr module CMakeLists for the ElemRV-N + GPIO + UART slice.
+# No custom drivers shipped in this PR; later slices add drivers/{pwm,
+# pio, pinctrl, spi} and the corresponding include directory.

--- a/digital-twin/zephyr/elemrv-zephyr/Kconfig
+++ b/digital-twin/zephyr/elemrv-zephyr/Kconfig
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Minimal Zephyr module Kconfig for the ElemRV-N + GPIO + UART slice.
+# No custom drivers in this slice (blinky uses upstream litex,gpio and
+# litex,timer drivers via the DT compatible strings).

--- a/digital-twin/zephyr/elemrv-zephyr/app/blinky/CMakeLists.txt
+++ b/digital-twin/zephyr/elemrv-zephyr/app/blinky/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(blinky)
+
+target_sources(app PRIVATE src/main.c)

--- a/digital-twin/zephyr/elemrv-zephyr/app/blinky/prj.conf
+++ b/digital-twin/zephyr/elemrv-zephyr/app/blinky/prj.conf
@@ -1,0 +1,2 @@
+# Blinky: GPIO + Timer validation for ElemRV.
+# GPIO is enabled in board defconfig.

--- a/digital-twin/zephyr/elemrv-zephyr/app/blinky/src/main.c
+++ b/digital-twin/zephyr/elemrv-zephyr/app/blinky/src/main.c
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * ElemRV Blinky: Validates GPIO output + Timer-based k_sleep.
+ * Toggles LED0 (GPIO0 pin 0) with 250 ms interval using k_sleep.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
+
+#define SLEEP_TIME_MS 250
+#define NUM_TOGGLES   8
+
+#define LED0_NODE DT_ALIAS(led0)
+
+static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
+
+int main(void)
+{
+	int ret;
+
+	printk("ElemRV Blinky (GPIO + Timer test)\n");
+
+	if (!gpio_is_ready_dt(&led)) {
+		printk("ERROR: GPIO device not ready\n");
+		return -1;
+	}
+
+	ret = gpio_pin_configure_dt(&led, GPIO_OUTPUT_ACTIVE);
+	if (ret < 0) {
+		printk("ERROR: gpio_pin_configure failed: %d\n", ret);
+		return -1;
+	}
+
+	printk("GPIO configured, starting %d toggles at %d ms interval\n",
+	       NUM_TOGGLES, SLEEP_TIME_MS);
+
+	for (int i = 0; i < NUM_TOGGLES; i++) {
+		gpio_pin_toggle_dt(&led);
+		printk("Toggle %d\n", i);
+		k_sleep(K_MSEC(SLEEP_TIME_MS));
+	}
+
+	printk("GPIO + Timer Test PASSED\n");
+	return 0;
+}

--- a/digital-twin/zephyr/elemrv-zephyr/boards/aesc/elemrv_n/Kconfig.defconfig
+++ b/digital-twin/zephyr/elemrv-zephyr/boards/aesc/elemrv_n/Kconfig.defconfig
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_ELEMRV_N
+
+config BOARD
+	default "elemrv_n"
+
+endif # BOARD_ELEMRV_N

--- a/digital-twin/zephyr/elemrv-zephyr/boards/aesc/elemrv_n/Kconfig.elemrv_n
+++ b/digital-twin/zephyr/elemrv-zephyr/boards/aesc/elemrv_n/Kconfig.elemrv_n
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_ELEMRV_N
+	select SOC_ELEMRV_N_VEXRISCV

--- a/digital-twin/zephyr/elemrv-zephyr/boards/aesc/elemrv_n/board.yml
+++ b/digital-twin/zephyr/elemrv-zephyr/boards/aesc/elemrv_n/board.yml
@@ -1,0 +1,6 @@
+board:
+  name: elemrv_n
+  full_name: ElemRV Nitrogen RISC-V SoC
+  vendor: aesc
+  socs:
+    - name: elemrv_n_vexriscv

--- a/digital-twin/zephyr/elemrv-zephyr/boards/aesc/elemrv_n/elemrv_n.dts
+++ b/digital-twin/zephyr/elemrv-zephyr/boards/aesc/elemrv_n/elemrv_n.dts
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * ElemRV Nitrogen board device tree.
+ * VexRiscv RV32IMC @ 20 MHz, 4 KB SRAM, 64 KB Flash (XIP).
+ */
+
+/dts-v1/;
+
+#include <riscv32-elemrv-n-vexriscv.dtsi>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/ {
+	model = "ElemRV Nitrogen";
+	compatible = "aesc,elemrv-n";
+
+	chosen {
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+		zephyr,sram = &ram0;
+		zephyr,flash = &flash0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led0: led_0 {
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+			label = "LED0";
+		};
+	};
+
+	aliases {
+		led0 = &led0;
+	};
+
+	ram0: memory@80000000 {
+		device_type = "memory";
+		reg = <0x80000000 0x1000>;
+	};
+
+	flash0: memory@a0000000 {
+		reg = <0xa0000000 0x10000>;
+	};
+};
+
+&uart0 {
+	status = "okay";
+	current-speed = <115200>;
+};
+
+&timer0 {
+	status = "okay";
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&i2c0 {
+	status = "okay";
+};

--- a/digital-twin/zephyr/elemrv-zephyr/boards/aesc/elemrv_n/elemrv_n.yaml
+++ b/digital-twin/zephyr/elemrv-zephyr/boards/aesc/elemrv_n/elemrv_n.yaml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+
+identifier: elemrv_n
+name: ElemRV Nitrogen RISC-V SoC
+type: mcu
+arch: riscv
+toolchain:
+  - zephyr
+ram: 4
+flash: 64
+supported:
+  - uart
+  - gpio
+  - i2c
+vendor: aesc

--- a/digital-twin/zephyr/elemrv-zephyr/boards/aesc/elemrv_n/elemrv_n_defconfig
+++ b/digital-twin/zephyr/elemrv-zephyr/boards/aesc/elemrv_n/elemrv_n_defconfig
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Console
+CONFIG_CONSOLE=y
+CONFIG_SERIAL=y
+CONFIG_UART_CONSOLE=y
+CONFIG_UART_INTERRUPT_DRIVEN=y
+
+# XIP: code executes from Flash, only data in RAM (matches real HW: 4 KB SRAM)
+CONFIG_XIP=y
+
+# GPIO (LiteX GPIO driver, auto-selected by DT compatible)
+CONFIG_GPIO=y
+
+# I2C (LiteX I2C bit-bang driver, auto-selected by DT compatible)
+CONFIG_I2C=y
+
+# Size optimization for constrained RAM (4 KB)
+CONFIG_SIZE_OPTIMIZATIONS=y
+CONFIG_HEAP_MEM_POOL_SIZE=512
+CONFIG_MAIN_STACK_SIZE=512
+CONFIG_IDLE_STACK_SIZE=256
+CONFIG_ISR_STACK_SIZE=512

--- a/digital-twin/zephyr/elemrv-zephyr/dts/riscv/riscv32-elemrv-n-vexriscv.dtsi
+++ b/digital-twin/zephyr/elemrv-zephyr/dts/riscv/riscv32-elemrv-n-vexriscv.dtsi
@@ -1,0 +1,118 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * ElemRV-N VexRiscv SoC device tree include.
+ * CPU: VexRiscv RV32IMC @ 20 MHz, Wishbone bus, LiteX-compatible peripherals.
+ */
+
+#include <zephyr/dt-bindings/i2c/i2c.h>
+
+/ {
+	#address-cells = <1>;
+	#size-cells = <1>;
+	compatible = "aesc,elemrv-n-vexriscv", "litex-dev";
+	model = "aesc,elemrv-n-vexriscv";
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		cpu0: cpu@0 {
+			clock-frequency = <20000000>;
+			compatible = "litex,vexriscv-standard", "riscv";
+			device_type = "cpu";
+			reg = <0>;
+			riscv,isa = "rv32imc_zicsr_zifencei";
+			status = "okay";
+		};
+	};
+
+	soc {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "aesc,elemrv-n-vexriscv";
+		ranges;
+
+		intc0: interrupt-controller@bc0 {
+			compatible = "litex,vexriscv-intc0";
+			#address-cells = <0>;
+			#interrupt-cells = <2>;
+			interrupt-controller;
+			reg = <0xbc0 0x4 0xfc0 0x4>;
+			reg-names = "irq_mask", "irq_pending";
+			riscv,max-priority = <7>;
+		};
+
+		uart0: serial@f0006000 {
+			compatible = "litex,uart";
+			interrupt-parent = <&intc0>;
+			interrupts = <0 10>;
+			reg = <0xf0006000 0x4
+				0xf0006004 0x4
+				0xf0006008 0x4
+				0xf000600c 0x4
+				0xf0006010 0x4
+				0xf0006014 0x4
+				0xf0006018 0x4
+				0xf000601c 0x4>;
+			reg-names =
+				"rxtx",
+				"txfull",
+				"rxempty",
+				"ev_status",
+				"ev_pending",
+				"ev_enable",
+				"txempty",
+				"rxfull";
+			status = "disabled";
+		};
+
+		timer0: timer@f0020000 {
+			compatible = "litex,timer0";
+			interrupt-parent = <&intc0>;
+			interrupts = <1 0>;
+			reg = <0xf0020000 0x4
+				0xf0020004 0x4
+				0xf0020008 0x4
+				0xf002000c 0x4
+				0xf0020010 0x4
+				0xf0020014 0x4
+				0xf0020018 0x4
+				0xf002001c 0x4
+				0xf0020020 0x4
+				0xf0020024 0x8>;
+			reg-names =
+				"load",
+				"reload",
+				"en",
+				"update_value",
+				"value",
+				"ev_status",
+				"ev_pending",
+				"ev_enable",
+				"uptime_latch",
+				"uptime_cycles";
+			status = "disabled";
+		};
+
+		gpio0: gpio@f0000000 {
+			compatible = "litex,gpio";
+			reg = <0xf0000000 0x4>;
+			reg-names = "control";
+			ngpios = <20>;
+			port-is-output;
+			status = "disabled";
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		i2c0: i2c@f0001000 {
+			compatible = "litex,i2c";
+			reg = <0xf0001000 0x4 0xf0001004 0x4>;
+			reg-names = "write", "read";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+	};
+};

--- a/digital-twin/zephyr/elemrv-zephyr/soc/aesc/elemrv_n_vexriscv/CMakeLists.txt
+++ b/digital-twin/zephyr/elemrv-zephyr/soc/aesc/elemrv_n_vexriscv/CMakeLists.txt
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_sources(
+    ${ZEPHYR_BASE}/soc/common/riscv-privileged/soc_irq.S
+    ${ZEPHYR_BASE}/soc/common/riscv-privileged/vector.S
+)
+
+zephyr_include_directories(.)
+
+set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/riscv/common/linker.ld CACHE INTERNAL "")

--- a/digital-twin/zephyr/elemrv-zephyr/soc/aesc/elemrv_n_vexriscv/Kconfig
+++ b/digital-twin/zephyr/elemrv-zephyr/soc/aesc/elemrv_n_vexriscv/Kconfig
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_ELEMRV_N_VEXRISCV
+	select RISCV
+	select ATOMIC_OPERATIONS_C
+	select INCLUDE_RESET_VECTOR
+	select RISCV_ISA_RV32I
+	select RISCV_ISA_EXT_M
+	select RISCV_ISA_EXT_C
+	select RISCV_ISA_EXT_ZICSR
+	select RISCV_ISA_EXT_ZIFENCEI
+	imply XIP
+
+if SOC_ELEMRV_N_VEXRISCV
+
+config LITEX_CSR_DATA_WIDTH
+	int "LiteX CSR data width"
+	default 32
+	help
+	  Width of the LiteX CSR bus registers. ElemRV-N uses 32-bit CSRs.
+
+endif # SOC_ELEMRV_N_VEXRISCV

--- a/digital-twin/zephyr/elemrv-zephyr/soc/aesc/elemrv_n_vexriscv/Kconfig.defconfig
+++ b/digital-twin/zephyr/elemrv-zephyr/soc/aesc/elemrv_n_vexriscv/Kconfig.defconfig
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_ELEMRV_N_VEXRISCV
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
+
+config NUM_IRQS
+	default 12
+
+endif # SOC_ELEMRV_N_VEXRISCV

--- a/digital-twin/zephyr/elemrv-zephyr/soc/aesc/elemrv_n_vexriscv/Kconfig.soc
+++ b/digital-twin/zephyr/elemrv-zephyr/soc/aesc/elemrv_n_vexriscv/Kconfig.soc
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_ELEMRV_N_VEXRISCV
+	bool
+	help
+	  ElemRV Nitrogen VexRiscv RV32IMC SoC with LiteX-compatible peripherals.
+
+config SOC
+	default "elemrv_n_vexriscv" if SOC_ELEMRV_N_VEXRISCV

--- a/digital-twin/zephyr/elemrv-zephyr/soc/aesc/elemrv_n_vexriscv/soc.h
+++ b/digital-twin/zephyr/elemrv-zephyr/soc/aesc/elemrv_n_vexriscv/soc.h
@@ -1,0 +1,147 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * ElemRV-N VexRiscv SoC helpers: LiteX CSR access functions.
+ * Mirrors soc/litex/litex_vexriscv/soc.h so upstream LiteX drivers work.
+ */
+
+#ifndef __RISCV32_ELEMRV_N_VEXRISCV_SOC_H_
+#define __RISCV32_ELEMRV_N_VEXRISCV_SOC_H_
+
+#include <zephyr/devicetree.h>
+#include <zephyr/arch/riscv/sys_io.h>
+
+#ifndef _ASMLANGUAGE
+
+static inline unsigned char litex_read8(unsigned long addr)
+{
+#if CONFIG_LITEX_CSR_DATA_WIDTH >= 32
+	return sys_read32(addr) & 0xff;
+#else
+	return sys_read8(addr);
+#endif
+}
+
+static inline unsigned short litex_read16(unsigned long addr)
+{
+#if CONFIG_LITEX_CSR_DATA_WIDTH == 8
+	return (sys_read8(addr) << 8) | sys_read8(addr + 0x4);
+#elif CONFIG_LITEX_CSR_DATA_WIDTH >= 32
+	return sys_read32(addr) & 0xffff;
+#else
+	return sys_read16(addr);
+#endif
+}
+
+static inline unsigned int litex_read32(unsigned long addr)
+{
+#if CONFIG_LITEX_CSR_DATA_WIDTH == 8
+	return (sys_read8(addr) << 24)
+		| (sys_read8(addr + 0x4) << 16)
+		| (sys_read8(addr + 0x8) << 8)
+		| sys_read8(addr + 0xc);
+#else
+	return sys_read32(addr);
+#endif
+}
+
+static inline uint64_t litex_read64(unsigned long addr)
+{
+#if CONFIG_LITEX_CSR_DATA_WIDTH == 32
+	return ((uint64_t)sys_read32(addr) << 32) | (uint64_t)sys_read32(addr + 0x4);
+#else
+	return (((uint64_t)sys_read8(addr)) << 56)
+		| ((uint64_t)sys_read8(addr + 0x4) << 48)
+		| ((uint64_t)sys_read8(addr + 0x8) << 40)
+		| ((uint64_t)sys_read8(addr + 0xc) << 32)
+		| ((uint64_t)sys_read8(addr + 0x10) << 24)
+		| ((uint64_t)sys_read8(addr + 0x14) << 16)
+		| ((uint64_t)sys_read8(addr + 0x18) << 8)
+		| (uint64_t)sys_read8(addr + 0x1c);
+#endif
+}
+
+static inline void litex_write8(unsigned char value, unsigned long addr)
+{
+#if CONFIG_LITEX_CSR_DATA_WIDTH >= 32
+	sys_write32((uint32_t)value, addr);
+#else
+	sys_write8(value, addr);
+#endif
+}
+
+static inline void litex_write16(unsigned short value, unsigned long addr)
+{
+#if CONFIG_LITEX_CSR_DATA_WIDTH == 8
+	sys_write8(value >> 8, addr);
+	sys_write8(value, addr + 0x4);
+#elif CONFIG_LITEX_CSR_DATA_WIDTH >= 32
+	sys_write32((uint32_t)value, addr);
+#else
+	sys_write16(value, addr);
+#endif
+}
+
+static inline void litex_write32(unsigned int value, unsigned long addr)
+{
+#if CONFIG_LITEX_CSR_DATA_WIDTH == 8
+	sys_write8(value >> 24, addr);
+	sys_write8(value >> 16, addr + 0x4);
+	sys_write8(value >> 8, addr + 0x8);
+	sys_write8(value, addr + 0xC);
+#else
+	sys_write32(value, addr);
+#endif
+}
+
+static inline void litex_write64(uint64_t value, unsigned long addr)
+{
+#if CONFIG_LITEX_CSR_DATA_WIDTH == 32
+	sys_write32(value >> 32, addr);
+	sys_write32(value, addr + 0x4);
+#else
+	sys_write8(value >> 56, addr);
+	sys_write8(value >> 48, addr + 0x4);
+	sys_write8(value >> 40, addr + 0x8);
+	sys_write8(value >> 32, addr + 0xC);
+	sys_write8(value >> 24, addr + 0x10);
+	sys_write8(value >> 16, addr + 0x14);
+	sys_write8(value >> 8, addr + 0x18);
+	sys_write8(value, addr + 0x1C);
+#endif
+}
+
+static inline void litex_write(uint32_t addr, uint32_t size, uint32_t value)
+{
+	switch (size) {
+	case 1:
+		litex_write8(value, addr);
+		break;
+	case 2:
+		litex_write16(value, addr);
+		break;
+	case 4:
+		litex_write32(value, addr);
+		break;
+	default:
+		break;
+	}
+}
+
+static inline uint32_t litex_read(uint32_t addr, uint32_t size)
+{
+	switch (size) {
+	case 1:
+		return litex_read8(addr);
+	case 2:
+		return litex_read16(addr);
+	case 4:
+		return litex_read32(addr);
+	default:
+		return 0;
+	}
+}
+
+#endif /* _ASMLANGUAGE */
+
+#endif /* __RISCV32_ELEMRV_N_VEXRISCV_SOC_H_ */

--- a/digital-twin/zephyr/elemrv-zephyr/soc/aesc/elemrv_n_vexriscv/soc.yml
+++ b/digital-twin/zephyr/elemrv-zephyr/soc/aesc/elemrv_n_vexriscv/soc.yml
@@ -1,0 +1,2 @@
+socs:
+- name: elemrv_n_vexriscv

--- a/digital-twin/zephyr/elemrv-zephyr/west.yml
+++ b/digital-twin/zephyr/elemrv-zephyr/west.yml
@@ -1,0 +1,17 @@
+manifest:
+  self:
+    path: elemrv-zephyr
+
+  remotes:
+    - name: zephyrproject-rtos
+      url-base: https://github.com/zephyrproject-rtos
+
+  projects:
+    - name: zephyr
+      remote: zephyrproject-rtos
+      revision: v4.1.0
+      import:
+        name-allowlist:
+          - cmsis
+          - cmsis_6
+          - hal_riscv

--- a/digital-twin/zephyr/elemrv-zephyr/zephyr/module.yml
+++ b/digital-twin/zephyr/elemrv-zephyr/zephyr/module.yml
@@ -1,0 +1,7 @@
+build:
+  kconfig: Kconfig
+  cmake: .
+  settings:
+    board_root: .
+    dts_root: .
+    soc_root: .


### PR DESCRIPTION
Hi! following up on #13. This is the small first slice we agreed on: ElemRV-N with GPIO and UART, plus a Zephyr blinky to exercise both end-to-end. Nothing outside `digital-twin/` and one new GitHub Actions workflow gets touched, so it should be easy to drop in or carve back out.

The flow it gives you: Scala (`digital-twin/scala/elemrv_n/...`) generates the WishboneGpio and WishboneUart Verilog, Verilator builds shared libraries from that Verilog, Renode loads them as `CoSimulatedPeripheral` instances, and a stock Zephyr 4.1 blinky app runs against them. The same Verilog is also exercised in pure Verilator testbenches (no Renode in the loop) so the wrappers can be regressed in isolation. There is also a baseline test that just boots the bare N platform without any co-simulation, which is useful as a sanity check before anyone touches the cosim path.

The Zephyr side ships a minimal module under `digital-twin/zephyr/elemrv-zephyr/` with the `aesc/elemrv_n` board, the `elemrv_n_vexriscv` SoC, and only the blinky app. The DTSI is trimmed to what's needed for this slice (GPIO, UART, Timer, I2C, all using upstream `litex,*` bindings), so no custom DT bindings need to ship yet. The SPI node is intentionally absent for now; it comes back with the SPI cosim PR along with the `aesc,nafarr-spi` binding.

On the build side, the DT lives in its own SBT sub-project (`digital-twin/build.sbt`) that depends only on nafarr + SpinalHDL. It doesn't reach into `hardware/scala/` or share a build with the upstream root project, so a future regression in the root build won't take cosim down with it (and vice versa). The wrappers' Makefiles take `RENODE_ROOT` as an env var (default `/opt/renode_1.16.0_portable`) so the container layout can change without editing them.

## Build and test

The full run, from a fresh clone:

```bash
task install                                                # bootstrap nafarr et al

cd digital-twin
sbt "runMain elemrv_n.test.WishboneGpioNVerilog"
sbt "runMain elemrv_n.test.WishboneUartLiteVerilog"
cd ..

cd digital-twin/renode/verilated/wrappers
bash build_n_cosim.sh release                               # libgpio_n.so + libuart_lite.so
cd ../../../..

cd digital-twin/zephyr
west init -l elemrv-zephyr 2>/dev/null || true
west update
cd elemrv-zephyr
west build -b elemrv_n app/blinky -d build-n-blinky
cd ../../..

cd digital-twin/renode && bash run_tests.sh                 # SUMMARY: 5/5 passed
```

The 5 tests are: N base platform (Renode-only sanity), N GPIO cosim, N UART Lite cosim, the pure Verilator testbenches, and the Zephyr blinky end-to-end. Tests 2, 3 and 5 self-skip with a clear message when the corresponding `.so` or ELF is missing, so partial setups don't false-fail.

On my workstation the slice currently sits at `libgpio_n.so` ~312 KiB, `libuart_lite.so` ~317 KiB, blinky ELF ~12 KiB (ROM 18.89%, RAM 60.84% of the 4 KiB SRAM), and the suite runs comfortably in a few seconds.

## CI and container

`.github/workflows/digital-twin-tests.yaml` is `workflow_dispatch` only with a `container_image` input, so it doesn't run on every push until you point it at the right image. The workflow fails fast with a clear message if the image isn't there.

Looking at `elements-container/Containerfile` on main, the heavy stuff (sbt, JDK 11, Python 3 + west, CMake, ninja, Zephyr SDK with `riscv64-zephyr-elf`, Renode 1.16.1, Verilator) is already in place, so the cosim build and Zephyr blinky build run out of the box on top of that image. The DT side just needs two things to be true: `RENODE_ROOT` points at the directory that contains `plugins/IntegrationLibrary/` (default `/opt/renode_1.16.0_portable`, easy to override if the apt `.deb` puts pieces elsewhere), and `device-tree-compiler` (`dtc`) is installed; that one isn't in the final stage of the image yet and Zephyr needs it. `digital-twin/README.md` has the full "Container requirements" section in case you want the exact version floors.

## Follow-ups

Keeping this PR small means there's a small backlog we can sequence as separate slices, all on ElemRV-N (matching your "focus on Nitrogen once H stabilizes" plan):

- Pinmux + SPI + I2C cosim for N (adds the `aesc,nafarr-spi` binding, `WishboneSpiController` / `WishboneI2cController` wrappers, and the matching `.repl` variants).
- PWM driver + cosim for N (you mentioned PWM is missing upstream).
- BMB co-simulation and SPI XIP, then the CPU-driven XIP path via tlib's executable-IO flag. These are the most invasive bits of the DT (Verilator runs every instruction fetch when XIP is co-simulated) so they really benefit from landing late, once the smaller peripherals have shaken out the wrapper conventions.
- Optional later: a thread-aware RTOS debug demo (Zephyr + Renode GDB), a small fault-injection harness, and a multi-node IoT demo. None of these need to ship until you ask for them; flagging only so you know where the rest of our internal DT tree is heading.

If/when you want to revisit H, we can rebuild the H-side of the DT on top of whatever VexiiRiscv variant you settle on. Easier to do that once your H rework is in than to ship an H DT layer that doesn't match the new chip.

## References

- Issue: https://github.com/aesc-silicon/ElemRV/issues/13
- The N+GPIO+UART scope decision: #4351154911 and #4355589207
- Container ownership: #4365667159
- Internal full DT tree for reference (H, SPI XIP, multi-node, etc., not for review here): https://github.com/Mauricio-xx/ElemRV/tree/dev-mont/digital-twin
