### PR TITLE
Update ElemRV-H

### DIFF
--- a/.claude/commands/update-chip-size.md
+++ b/.claude/commands/update-chip-size.md
@@ -1,0 +1,56 @@
+# Update Chip Size
+
+Recalculate and update the `dieArea` and `coreArea` for a chip target based on the current utilization density.
+
+## Input
+
+The user provides:
+- **Chip**: e.g. `ElemRV-H` or `ElemRV-N` (maps to `hardware/scala/elemrv_h/` or `elemrv_n/`)
+- **Platform**: e.g. `SG13G2` (maps to `<chip_dir>/SG13G2/SG13G2.scala`)
+- **Current density**: the density reported by the place-and-route tool (e.g. `95%`)
+- **Target density** (optional): defaults to `80%` if not specified
+
+## PDK Reference
+
+Look up the platform in this table to determine the PDK, manufacturer grid, and IO ring margins.
+
+| Platform   | PDK      | X Grid (µm) | Y Grid (µm) | Core Margin Left (µm) | Core Margin Bottom (µm) | Core Margin Right (µm) | Core Margin Top (µm) |
+|------------|----------|-------------|-------------|----------------------|------------------------|----------------------|---------------------|
+| SG13G2     | IHP      | 0.48        | 3.78        | 394.08               | 396.9                  | 396.96               | 396.9               |
+| SG13CMOS5l | IHP      | 0.48        | 3.78        | 394.08               | 396.9                  | 396.96               | 396.9               |
+| GF180MCU   | GF180MCU | TBD         | TBD         | TBD                  | TBD                    | TBD                  | TBD                 |
+| SKY130     | SKY130   | TBD         | TBD         | TBD                  | TBD                    | TBD                  | TBD                 |
+
+If any required value is `TBD`, abort and tell the user that the PDK parameters for this platform are not yet configured.
+
+## Procedure
+
+1. **Locate the file**: Map the chip name to its directory under `hardware/scala/` (e.g. `ElemRV-H` → `elemrv_h`, `ElemRV-N` → `elemrv_n`). The platform file is at `hardware/scala/<chip_dir>/<Platform>/<Platform>.scala`.
+
+2. **Look up PDK parameters** from the table above using the platform name. Abort if any values are TBD.
+
+3. **Read the file** and extract the current `chip.dieArea` and `chip.coreArea` values. These are tuples of 4 doubles: `(x1, y1, x2, y2)`. Only update lines that set `chip.dieArea` and `chip.coreArea` — NOT sub-block die/core areas (e.g. `hyperbus.dieArea`, `cpu.dieArea`).
+
+4. **Calculate new dimensions**:
+   - Current core width = `x2 - x1` of coreArea
+   - Current core height = `y2 - y1` of coreArea
+   - Current core area = width × height
+   - Utilized area = current core area × (current density / 100)
+   - New core area = utilized area / (target density / 100)
+   - Scale factor = sqrt(new core area / current core area)
+   - New core width = current core width × scale factor
+   - New core height = current core height × scale factor
+
+5. **Snap to manufacturer grid**:
+   - X values must be multiples of the PDK's X Grid
+   - Y values must be multiples of the PDK's Y Grid
+   - Round new core dimensions **up** (ceiling) to the grid
+
+6. **Compute new areas** using the PDK's IO ring margins:
+   - New core: `(margin_left, margin_bottom, margin_left + new_core_width, margin_bottom + new_core_height)`
+   - New die: `(0, 0, margin_left + new_core_width + margin_right, margin_bottom + new_core_height + margin_top)`
+   - Snap the die `x2` up to the nearest multiple of X Grid and die `y2` up to the nearest multiple of Y Grid
+
+7. **Update the file**: Replace only the `chip.dieArea` and `chip.coreArea` lines with the new values. Format numbers with 2 decimal places.
+
+8. **Report the changes**: Show the old and new values, the old and new core area in µm², and the expected new density.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -34,3 +34,8 @@ SPDX-License-Identifier = "CERN-OHL-W-2.0"
 path = "docs/**"
 SPDX-FileCopyrightText = "2026 aesc silicon"
 SPDX-License-Identifier = "CERN-OHL-W-2.0"
+
+[[annotations]]
+path = ".claude/**"
+SPDX-FileCopyrightText = "2026 aesc silicon"
+SPDX-License-Identifier = "CERN-OHL-W-2.0"

--- a/Taskfile.baremetal.yml
+++ b/Taskfile.baremetal.yml
@@ -20,14 +20,14 @@ tasks:
     cmds:
       - task: ':lib-baremetal-firmware'
         vars:
-         app: "bootrom"
+          app: "bootrom"
       - task: ':lib-baremetal-firmware'
         vars:
-         app: "demo"
+          app: "demo"
       - "{{.RUN}} './software/{{.package}}/gen_baremetal_container.sh'"
-      - "{{.RUN}} 'ln -sf {{.BUILD_ROOT}}/{{.SOC}}/{{.board}}/firmware/baremetal_container.img {{.BUILD_ROOT}}/{{.SOC}}/{{.board}}/firmware/image_container.img'"
+      - "{{.RUN}} 'ln -sf {{.BUILD_ROOT}}/{{.SOC}}/firmware/baremetal_container.img {{.BUILD_ROOT}}/{{.SOC}}/firmware/image_container.img'"
 
   flash:
     desc: Programs the SPI flash with the compiled baremetal firmware image.
     cmds:
-      - "flashrom -p buspirate_spi:dev=/dev/serial/by-id/usb-Bus_Pirate_Bus_Pirate_5_5buspirate-if02,spispeed=8M -c MT25QL256 -l software/{{.package}}/spi.layout -i flash -n -w {{.BUILD_ROOT}}/{{.SOC}}/{{.board}}/firmware/baremetal_container.img"
+      - "flashrom -p buspirate_spi:dev=/dev/serial/by-id/usb-Bus_Pirate_Bus_Pirate_5_5buspirate-if02,spispeed=8M -c MT25QL128 -l software/{{.package}}/spi.layout -i flash -n -w {{.BUILD_ROOT}}/{{.SOC}}/firmware/baremetal_container.img"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -24,6 +24,7 @@ vars:
     sh: |
       case "{{.PDK}}" in
         ihp-sg13g2) echo "sg13g2" ;;
+        ihp-sg13cmos5l) echo "sg13cmos5l" ;;
         sky130A)    echo "sky130" ;;
         gf180mcuD)  echo "gf180mcu" ;;
         *) echo ""; echo "Unknown PDK: {{.PDK}}" >&2; exit 1 ;;
@@ -32,6 +33,7 @@ vars:
     sh: |
       case "{{.PDK}}" in
         ihp-sg13g2) echo "ihp-sg13g2" ;;
+        ihp-sg13cmos5l) echo "ihp-sg13g2" ;;
         sky130A)    echo "sky130" ;;
         gf180mcuD)  echo "gf180mcu" ;;
         *) echo ""; echo "Unknown PDK: {{.PDK}}" >&2; exit 1 ;;
@@ -40,6 +42,7 @@ vars:
     sh: |
       case "{{.PDK}}" in
         ihp-sg13g2) echo "ihp-sg13g2" ;;
+        ihp-sg13cmos5l) echo "ihp-sg13g2" ;;
         sky130A)    echo "sky130hd" ;;
         gf180mcuD)  echo "gf180" ;;
         *) echo ""; echo "Unknown PDK: {{.PDK}}" >&2; exit 1 ;;
@@ -48,6 +51,7 @@ vars:
     sh: |
       case "{{.PDK}}" in
         ihp-sg13g2) echo "5cccb161f7492697cfa52eb14dc03beb00bdca9e" ;;
+        ihp-sg13cmos5l) echo "5cccb161f7492697cfa52eb14dc03beb00bdca9e" ;;
         sky130A)    echo "7b70722e33c03fcb5dabcf4d479fb0822d9251c9" ;;
         gf180mcuD)  echo "7b70722e33c03fcb5dabcf4d479fb0822d9251c9" ;;
         *) echo ""; echo "Unknown PDK: {{.PDK}}" >&2; exit 1 ;;

--- a/Taskfile.zephyr.yml
+++ b/Taskfile.zephyr.yml
@@ -23,13 +23,12 @@ tasks:
           app: "bootrom"
       - task: ':lib-zephyr-firmware'
         vars:
-          boardname: "elemrv/{{.package}}"
+          boardname: "elemrv_flask/{{.package}}"
+          app: "{{.ZEPHYR_APP | default \"modules/elements/zephyr/samples/basic/blinky\"}}"
       - "{{.RUN}} './software/{{.package}}/gen_zephyr_container.sh'"
-      - "{{.RUN}} 'ln -sf {{.BUILD_ROOT}}/{{.SOC}}/{{.board}}/firmware/zephyr_container.img {{.BUILD_ROOT}}/{{.SOC}}/{{.board}}/firmware/image_container.img'"
-    vars:
-      app: "modules/elements/zephyr/samples/hello_world"
+      - "{{.RUN}} 'ln -sf {{.BUILD_ROOT}}/{{.SOC}}/firmware/zephyr_container.img {{.BUILD_ROOT}}/{{.SOC}}/firmware/image_container.img'"
 
   flash:
     desc: Programs the SPI flash with the Zephyr image container.
     cmds:
-      - "flashrom -p buspirate_spi:dev=/dev/serial/by-id/usb-Bus_Pirate_Bus_Pirate_5_5buspirate-if02,spispeed=8M -c MT25QL256 -l software/{{.package}}/spi.layout -i flash -n -w {{.BUILD_ROOT}}/{{.SOC}}/{{.board}}/firmware/zephyr_container.img"
+      - "flashrom -p buspirate_spi:dev=/dev/serial/by-id/usb-Bus_Pirate_Bus_Pirate_5_5buspirate-if02,spispeed=8M -c MT25QL256 -l software/{{.package}}/spi.layout -i flash -n -w {{.BUILD_ROOT}}/{{.SOC}}/firmware/zephyr_container.img"

--- a/docs/source/nonmetals/elemrv_h.rst
+++ b/docs/source/nonmetals/elemrv_h.rst
@@ -2,8 +2,8 @@ ElemRV-H (Hydrogen)
 ###################
 
 ElemRV-H is the entry-level platform of the Nonmetal class. It is designed for
-minimal area and simplicity: a single-issue in-order CPU, a shared BMB bus, no
-caches, and a small set of low-speed peripherals. All IO is routed through a
+minimal area and simplicity: a single-issue in-order CPU, a TileLink shared bus,
+no caches, and a small set of low-speed peripherals. All IO is routed through a
 pinmux controller, making the 12 physical pins fully reconfigurable in software.
 
 Specifications
@@ -18,11 +18,11 @@ Specifications
    * - **Clock**
      - 50 MHz system
    * - **Interconnect**
-     - BMB shared bus
+     - TileLink shared bus
    * - **On-chip SRAM**
      - 8 kB
    * - **SPI Flash**
-     - 8 MB, Quad SPI XIP
+     - 512 kB, Quad SPI XIP
    * - **IO pins**
      - 12 (via pinmux)
    * - **Debug**
@@ -41,7 +41,7 @@ Memory Map
      - Description
    * - SPI Flash (XIP)
      - ``0xa0000000``
-     - 8 MB
+     - 512 kB
      - Code and read-only data
    * - On-chip SRAM
      - ``0x80000000``
@@ -56,6 +56,9 @@ Peripherals
 ***********
 
 Offsets are relative to the peripheral base address at ``0xf0000000``.
+
+User peripherals
+================
 
 .. list-table::
    :header-rows: 1
@@ -85,10 +88,66 @@ Offsets are relative to the peripheral base address at ``0xf0000000``.
      - ``0x4000``
      - 4 kB
      - UART with full handshake (TX, RX, CTS, RTS) - see :ref:`hardware-peripherals-uart`
+   * - PRNG
+     - ``0x5000``
+     - 4 kB
+     - Pseudo Random Number Generator - see :ref:`hardware-crypto-prng`
    * - Pinmux
      - ``0x10000``
      - 4 kB
      - Pin multiplexer for all 12 IO pins
+
+System peripherals
+==================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 15 50
+
+   * - Peripheral
+     - Offset
+     - Size
+     - Description
+   * - MachineTimer
+     - ``0x20000``
+     - 4 kB
+     - RISC-V machine-mode timer (mtime / mtimecmp)
+   * - ResetController
+     - ``0x21000``
+     - 4 kB
+     - Reset domain controller
+   * - ClockController
+     - ``0x22000``
+     - 4 kB
+     - Clock domain controller
+   * - Syscon
+     - ``0x23000``
+     - 4 kB
+     - System controller (board identity, feature flags, IP counts)
+   * - SpiFlash (config)
+     - ``0x24000``
+     - 4 kB
+     - SPI XIP controller configuration
+   * - SpiFlash (XIP ctrl)
+     - ``0x25000``
+     - 4 kB
+     - SPI XIP controller
+   * - Timer
+     - ``0x26000``
+     - 4 kB
+     - General-purpose timer - see :ref:`hardware-peripherals-timer`
+   * - Watchdog
+     - ``0x27000``
+     - 4 kB
+     - Watchdog timer with windowed mode and lock protection - see :ref:`hardware-system-watchdog`
+   * - ESM
+     - ``0x28000``
+     - 4 kB
+     - Error Signaling Module (optional) - see :ref:`hardware-system-esm`
+   * - PLIC
+     - ``0x800000``
+     - 4 MB
+     - Platform-Level Interrupt Controller
 
 Interrupts
 **********
@@ -105,6 +164,12 @@ Interrupts
      - Triggered on transfer completion or error
    * - UART0
      - Triggered on receive, transmit, or error conditions
+   * - Timer
+     - Triggered on counter expiry
+   * - Watchdog
+     - Triggered on timeout or window violation; error output triggers system reset
+   * - ESM
+     - Triggered on INFO or WARN severity events; ERROR/FATAL triggers system reset
 
 Pinmux
 ******

--- a/hardware/scala/elemrv_h/ECPIX5/ECPIX5.scala
+++ b/hardware/scala/elemrv_h/ECPIX5/ECPIX5.scala
@@ -7,21 +7,22 @@ package elemrv_h
 import spinal.core._
 import spinal.core.sim._
 import spinal.lib._
+import spinal.lib.bus.tilelink.{BusParameter => TileLinkParameter}
 
-import spinal.lib.bus.bmb._
-
+import nafarr.memory.ocram.ihp.sg13g2.TileLinkIhpOnChipRam
 import nafarr.system.reset._
 import nafarr.system.reset.ResetControllerCtrl._
 import nafarr.system.clock._
 import nafarr.system.clock.ClockControllerCtrl._
 import nafarr.blackboxes.lattice.ecp5._
-import nafarr.memory.ocram.ihp.sg13g2.BmbIhpOnChipRam
 
 import zibal.misc._
 import zibal.platform.Hydrogen
 import zibal.board.{KitParameter, BoardParameter}
 import zibal.sim.hyperram.W956A8MBYA
 import zibal.sim.MT25Q
+
+import nafarr.memory.ocram.TileLinkOnChipRam
 
 import elements.sdk.ElementsApp
 import elements.board.ECPIX5
@@ -99,7 +100,7 @@ case class ECPIX5Top() extends Component {
   val parameter = Hydrogen.Parameter(
     socParameter,
     8 kB,
-    8 MB,
+    512 kB,
     (parameter: ResetControllerCtrl.Parameter) => {
       val resetCtrl = new ResetControllerCtrl.GeneratorResetController(parameter)
       resetCtrl
@@ -115,8 +116,8 @@ case class ECPIX5Top() extends Component {
       )
       clockCtrl
     },
-    (parameter: BmbParameter, ramSize: BigInt) => {
-      val ram = BmbIhpOnChipRam.OnePort1Macro(parameter, ramSize.toInt)
+    onChipRamLogic = (p: TileLinkParameter, size: BigInt) => {
+      val ram = TileLinkIhpOnChipRam.OnePort(p, size.toInt)
       (ram, ram.io.bus)
     }
   )
@@ -216,11 +217,16 @@ case class ECPIX5Top() extends Component {
   for (index <- 0 until io.ledPullDown.length) {
     io.ledPullDown(index) <> FakeO(True)
   }
+
 }
 
 object ECPIX5Generate extends ElementsApp {
   val report = elementsConfig.genFPGASpinalConfig.generateVerilog {
     val top = ECPIX5Top()
+    BinTools.initRam(
+      top.soc.system.onChipRam.ctrl.asInstanceOf[TileLinkOnChipRam].ram,
+      elementsConfig.swStorageImageContainer
+    )
 
     val lpf = LatticeTools.Lpf(elementsConfig)
     lpf.generate(top.io)
@@ -233,7 +239,7 @@ object ECPIX5Generate extends ElementsApp {
 object ECPIX5Simulate extends ElementsApp {
   val compiled = elementsConfig.genFPGASimConfig.compile {
     val board = ECPIX5Board()
-    BinTools.initRam(board.spiNor.deviceOut.data, elementsConfig.swStorageBaremetalImage("demo"))
+    BinTools.initRam(board.spiNor.deviceOut.data, elementsConfig.swStorageImageContainer)
     for (domain <- board.top.soc.parameter.getKitParameter.clocks) {
       board.top.soc.clockCtrl.getClockDomainByName(domain.name).clock.simPublic()
     }

--- a/hardware/scala/elemrv_h/ElemRV.scala
+++ b/hardware/scala/elemrv_h/ElemRV.scala
@@ -12,24 +12,30 @@ import zibal.platform.Hydrogen
 import zibal.board.BoardParameter
 import zibal.soc.SocParameter
 
-import nafarr.peripherals.io.gpio.{WishboneGpio, Gpio, GpioCtrl}
-import nafarr.peripherals.io.pio.{WishbonePio, Pio, PioCtrl}
-import nafarr.peripherals.io.pwm.{WishbonePwm, Pwm, PwmCtrl}
-import nafarr.peripherals.com.uart.{WishboneUart, Uart, UartCtrl}
-import nafarr.peripherals.com.i2c.{WishboneI2cController, I2c, I2cControllerCtrl}
-import nafarr.peripherals.pinmux.{WishbonePinmux, Pinmux, PinmuxCtrl}
+import nafarr.peripherals.io.gpio.{TileLinkGpio, Gpio, GpioCtrl}
+import nafarr.peripherals.io.pio.{TileLinkPio, Pio, PioCtrl}
+import nafarr.peripherals.io.pwm.{TileLinkPwm, Pwm, PwmCtrl}
+import nafarr.peripherals.com.uart.{TileLinkUart, Uart, UartCtrl}
+import nafarr.peripherals.com.i2c.{TileLinkI2cController, I2c, I2cControllerCtrl}
+import nafarr.peripherals.pinmux.{TileLinkPinmux, Pinmux, PinmuxCtrl}
+import nafarr.crypto.crc.{TileLinkCrc32, Crc32Ctrl}
+import nafarr.crypto.prng.{TileLinkPrng, PrngCtrl}
 
 object ElemRV {
   def apply(parameter: Hydrogen.Parameter) = ElemRV(parameter)
 
-  case class Parameter(boardParameter: BoardParameter)
-      extends SocParameter(boardParameter, socInterrupts = 3) {
+  case class Parameter(boardParameter: BoardParameter) extends SocParameter(boardParameter) {
     val gpio0 = GpioCtrl.Parameter(Gpio.Parameter(12), 3)
     val i2c0 = I2cControllerCtrl.Parameter.default(1)
     val pio0 = PioCtrl.Parameter.default(3)
-    val pwm0 = PwmCtrl.Parameter.default(2)
+    val pwm0 = PwmCtrl.Parameter.default(1)
     val uart0 = UartCtrl.Parameter.full()
+    val prng = PrngCtrl.Parameter()
+    val crc32 = Crc32Ctrl.Parameter()
     val pinmux = PinmuxCtrl.Parameter(Pinmux.Parameter(12), 24, 2)
+
+    override val irqSources = Seq(gpio0, i2c0, pio0, pwm0, uart0)
+    override val errorSources = Seq(pio0, pwm0, uart0, prng)
   }
 
   case class ElemRV(parameter: Hydrogen.Parameter) extends Hydrogen.Hydrogen(parameter) {
@@ -40,42 +46,55 @@ object ElemRV {
 
     val peripherals = new ClockingArea(clockCtrl.getClockDomainByName("system")) {
 
-      val gpio0Ctrl = WishboneGpio(socParameter.gpio0, system.wishboneConfig)
+      val gpio0Ctrl = TileLinkGpio(socParameter.gpio0)
       addPeripheralDevice(gpio0Ctrl.io.bus, 0x0000, 4 kB)
       addInterrupt(gpio0Ctrl.io.interrupt)
       for (pin <- 0 until socParameter.gpio0.io.width) {
         addPinmuxInput(gpio0Ctrl.io.gpio.pins(pin), s"gpio0_$pin")
       }
 
-      val i2c0Ctrl = WishboneI2cController(socParameter.i2c0, system.wishboneConfig)
+      val i2c0Ctrl = TileLinkI2cController(socParameter.i2c0)
       addPeripheralDevice(i2c0Ctrl.io.bus, 0x1000, 4 kB)
       addInterrupt(i2c0Ctrl.io.interrupt)
       addPinmuxInput(i2c0Ctrl.io.i2c.scl, "i2c0_scl")
       addPinmuxInput(i2c0Ctrl.io.i2c.sda, "i2c0_sda")
       addPinmuxInput(i2c0Ctrl.io.i2c.interrupts(0), "i2c0_interrupt_0", output = false)
 
-      val pio0Ctrl = WishbonePio(socParameter.pio0, system.wishboneConfig)
+      val pio0Ctrl = TileLinkPio(socParameter.pio0)
       addPeripheralDevice(pio0Ctrl.io.bus, 0x2000, 4 kB)
+      addInterrupt(pio0Ctrl.io.interrupt)
+      addError(pio0Ctrl.io.error)
       for (pin <- 0 until socParameter.pio0.io.width) {
         addPinmuxInput(pio0Ctrl.io.pio.pins(pin), s"pio0_$pin")
       }
 
-      val pwm0Ctrl = WishbonePwm(socParameter.pwm0, system.wishboneConfig)
+      val pwm0Ctrl = TileLinkPwm(socParameter.pwm0)
       addPeripheralDevice(pwm0Ctrl.io.bus, 0x3000, 4 kB)
+      addInterrupt(pwm0Ctrl.io.interrupt)
+      addError(pwm0Ctrl.io.error)
       for (pin <- 0 until socParameter.pwm0.io.channels) {
-        addPinmuxInput(pwm0Ctrl.io.pwm.output(pin), s"pwm0_$pin")
+        addPinmuxInput(pwm0Ctrl.io.pwm.output(pin), s"pwm0_out_$pin")
+        addPinmuxInput(pwm0Ctrl.io.pwm.compOutput(pin), s"pwm0_comp_$pin")
       }
+      pwm0Ctrl.io.pwm.syncIn := False
+      pwm0Ctrl.io.pwm.faultIn := False
 
-      val uart0Ctrl = WishboneUart(socParameter.uart0, system.wishboneConfig)
+      val uart0Ctrl = TileLinkUart(socParameter.uart0)
       addPeripheralDevice(uart0Ctrl.io.bus, 0x4000, 4 kB)
       addInterrupt(uart0Ctrl.io.interrupt)
+      addError(uart0Ctrl.io.error)
       addPinmuxInput(uart0Ctrl.io.uart.txd, "uart0_tx")
       addPinmuxInput(uart0Ctrl.io.uart.rxd, "uart0_rx", output = false)
       addPinmuxInput(uart0Ctrl.io.uart.cts, "uart0_cts", output = false)
       addPinmuxInput(uart0Ctrl.io.uart.rts, "uart0_rts")
 
+      /* Crypto */
+      val prngCtrl = TileLinkPrng(socParameter.prng)
+      addPeripheralDevice(prngCtrl.io.bus, 0x5000, 4 kB)
+      addError(prngCtrl.io.error)
+
       /* Pin Mapping */
-      addPinmuxOption(0, List("gpio0_0", "pwm0_0"))
+      addPinmuxOption(0, List("gpio0_0", "pwm0_out_0"))
       addPinmuxOption(1, List("gpio0_1", "pio0_0"))
       addPinmuxOption(2, List("gpio0_2", "pio0_1"))
       addPinmuxOption(3, List("gpio0_3", "pio0_2"))
@@ -83,13 +102,12 @@ object ElemRV {
       addPinmuxOption(5, List("uart0_rx", "gpio0_5"))
       addPinmuxOption(6, List("uart0_cts", "gpio0_6"))
       addPinmuxOption(7, List("uart0_rts", "gpio0_7"))
-      addPinmuxOption(8, List("gpio0_8", "pwm0_1"))
+      addPinmuxOption(8, List("gpio0_8", "pwm0_comp_0"))
       addPinmuxOption(9, List("gpio0_9", "i2c0_scl"))
       addPinmuxOption(10, List("gpio0_10", "i2c0_sda"))
       addPinmuxOption(11, List("gpio0_11", "i2c0_interrupt_0"))
 
-      val pinmuxCtrl =
-        WishbonePinmux(socParameter.pinmux, getPinmuxMapping(), system.wishboneConfig)
+      val pinmuxCtrl = TileLinkPinmux(socParameter.pinmux, getPinmuxMapping())
       addPeripheralDevice(pinmuxCtrl.io.bus, 0x10000, 4 kB)
       io.pins <> pinmuxCtrl.io.pins
       connectPinmuxInputs(pinmuxCtrl)

--- a/hardware/scala/elemrv_h/SG13CMOS5L/SG13CMOS5L.scala
+++ b/hardware/scala/elemrv_h/SG13CMOS5L/SG13CMOS5L.scala
@@ -7,13 +7,13 @@ package elemrv_h
 import spinal.core._
 import spinal.core.sim._
 import spinal.lib._
-import spinal.lib.bus.bmb._
+import spinal.lib.bus.tilelink.{BusParameter => TileLinkParameter}
 
 import nafarr.system.reset._
 import nafarr.system.clock._
-import nafarr.blackboxes.ihp.sg13g2._
+import nafarr.blackboxes.ihp.sg13cmos5l._
 import nafarr.blackboxes.ihp.common._
-import nafarr.memory.ocram.ihp.sg13g2.BmbIhpOnChipRam
+import nafarr.memory.ocram.ihp.sg13g2.TileLinkIhpOnChipRam
 
 import zibal.misc._
 import zibal.platform.Hydrogen
@@ -22,9 +22,9 @@ import zibal.sim.hyperram.W956A8MBYA
 import zibal.sim.MT25Q
 
 import elements.sdk.ElementsApp
-import elements.board.ElemRVBoard
+import elements.board.ElemRVFlask
 
-case class SG13G2Board() extends Component {
+case class SG13CMOS5LBoard() extends Component {
   val io = new Bundle {
     val clock = inout(Analog(Bool))
     val reset = inout(Analog(Bool))
@@ -36,7 +36,7 @@ case class SG13G2Board() extends Component {
     val pins = Vec(inout(Analog(Bool())), 12)
   }
 
-  val top = SG13G2Top()
+  val top = SG13CMOS5LTop()
   val analogFalse = Analog(Bool)
   analogFalse := False
   val analogTrue = Analog(Bool)
@@ -69,23 +69,23 @@ case class SG13G2Board() extends Component {
 
 }
 
-case class SG13G2Top() extends Component {
+case class SG13CMOS5LTop() extends Component {
   val resets = List[ResetParameter](
     ResetParameter("system", 128),
     ResetParameter("debug", 128)
   )
-  val inputClock = ClockParameter("input", 50 MHz, "input")
+  val inputClock = ClockParameter("input", ElemRVFlask.Hydrogen.oscillatorFrequency, "input")
   val clocks = List[ClockParameter](
-    ClockParameter("system", 50 MHz, "system"),
-    ClockParameter("debug", 12.5 MHz, "debug", synchronousWith = "system")
+    ClockParameter("system", inputClock.frequency, "system"),
+    ClockParameter("debug", inputClock.frequency / 4, "debug", synchronousWith = "system")
   )
   val kitParameter = KitParameter(resets, clocks)
-  val boardParameter = ElemRVBoard.Parameter(kitParameter)
+  val boardParameter = ElemRVFlask.Hydrogen.Parameter(kitParameter)
   val socParameter = ElemRV.Parameter(boardParameter)
   val parameter = Hydrogen.Parameter(
     socParameter,
     8 kB,
-    8 MB,
+    512 kB,
     (parameter: ResetControllerCtrl.Parameter) => {
       val resetCtrl = new ResetControllerCtrl.DummyResetController(parameter)
       resetCtrl
@@ -101,8 +101,8 @@ case class SG13G2Top() extends Component {
       )
       clockCtrl
     },
-    (parameter: BmbParameter, ramSize: BigInt) => {
-      val ram = BmbIhpOnChipRam.OnePort1Macro(parameter, ramSize.toInt)
+    onChipRamLogic = (parameter: TileLinkParameter, ramSize: BigInt) => {
+      val ram = TileLinkIhpOnChipRam.OnePort(parameter, ramSize.toInt)
       (ram, ram.io.bus)
     }
   )
@@ -167,37 +167,45 @@ case class SG13G2Top() extends Component {
   }
 
   val power = Seq(
-    IhpPowerIo(Edge.South, 6, IhpPowerIoCell.SG13G2.Vss),
-    IhpPowerIo(Edge.South, 7, IhpPowerIoCell.SG13G2.Vdd),
-    IhpPowerIo(Edge.East, 6, IhpPowerIoCell.SG13G2.IOVdd),
-    IhpPowerIo(Edge.East, 7, IhpPowerIoCell.SG13G2.IOVss),
-    IhpPowerIo(Edge.North, 0, IhpPowerIoCell.SG13G2.Vss),
-    IhpPowerIo(Edge.North, 1, IhpPowerIoCell.SG13G2.Vdd),
-    IhpPowerIo(Edge.West, 0, IhpPowerIoCell.SG13G2.IOVdd),
-    IhpPowerIo(Edge.West, 1, IhpPowerIoCell.SG13G2.IOVss)
+    IhpPowerIo(Edge.South, 6, IhpPowerIoCell.SG13CMOS5L.Vss),
+    IhpPowerIo(Edge.South, 7, IhpPowerIoCell.SG13CMOS5L.Vdd),
+    IhpPowerIo(Edge.East, 6, IhpPowerIoCell.SG13CMOS5L.IOVss),
+    IhpPowerIo(Edge.East, 7, IhpPowerIoCell.SG13CMOS5L.IOVdd),
+    IhpPowerIo(Edge.North, 0, IhpPowerIoCell.SG13CMOS5L.Vdd),
+    IhpPowerIo(Edge.North, 1, IhpPowerIoCell.SG13CMOS5L.Vss),
+    IhpPowerIo(Edge.West, 0, IhpPowerIoCell.SG13CMOS5L.IOVdd),
+    IhpPowerIo(Edge.West, 1, IhpPowerIoCell.SG13CMOS5L.IOVss)
   )
 }
 
-object SG13G2Generate extends ElementsApp {
+object SG13CMOS5LGenerate extends ElementsApp {
   val report = elementsConfig.genASICSpinalConfig.generateVerilog {
-    val top = SG13G2Top()
+    val top = SG13CMOS5LTop()
 
     top.soc.prepareBaremetal("demo", elementsConfig)
 
     top
   }
 
-  val chip = OpenROADTools.IHP.Config(elementsConfig, OpenROADTools.PDKs.IHP.sg13g2)
-  chip.dieArea = (0, 0, 1892.64, 1893.78)
-  chip.coreArea = (394.08, 396.9, 1495.68, 1496.88)
+  val chip = OpenROADTools.IHP.Config(elementsConfig, OpenROADTools.PDKs.IHP.sg13cmos5l)
+  chip.dieArea = (0, 0, 1991.52, 1995.84)
+  chip.coreArea = (394.08, 396.9, 1594.56, 1598.94)
   chip.hasIoRing = true
   chip.addMacro(
-    report.toplevel.soc.system.onChipRam.ctrl.asInstanceOf[BmbIhpOnChipRam.OnePort1Macro].ram,
-    414.08,
-    416.68,
+    report.toplevel.soc.system.onChipRam.ctrl.asInstanceOf[TileLinkIhpOnChipRam.OnePort].rams(0),
+    434.08,
+    409.12,
     "MX",
     depth = 3
   )
+  chip.addMacro(
+    report.toplevel.soc.system.onChipRam.ctrl.asInstanceOf[TileLinkIhpOnChipRam.OnePort].rams(1),
+    1137.92,
+    409.12,
+    "MX",
+    depth = 3
+  )
+
   chip.addClock(report.toplevel.io.clock.PAD, report.toplevel.inputClock.frequency, "clk_main")
   chip.addClock(report.toplevel.io.jtag.tck.PAD, 10 MHz, "clk_jtag")
   chip.addGeneratedClock(
@@ -218,10 +226,10 @@ object SG13G2Generate extends ElementsApp {
   chip.generate
 }
 
-object SG13G2Simulate extends ElementsApp {
+object SG13CMOS5LSimulate extends ElementsApp {
   val compiled = elementsConfig.genFPGASimConfig.compile {
-    val board = SG13G2Board()
-    BinTools.initRam(board.spiNor.deviceOut.data, elementsConfig.swStorageBaremetalImage("demo"))
+    val board = SG13CMOS5LBoard()
+    BinTools.initRam(board.spiNor.deviceOut.data, elementsConfig.swStorageImageContainer)
     board
   }
   simType match {

--- a/hardware/scala/elemrv_h/SG13CMOS5L/rules.json
+++ b/hardware/scala/elemrv_h/SG13CMOS5L/rules.json
@@ -1,6 +1,6 @@
 {
     "synth__design__instance__area__stdcell": {
-        "value": 1520000.0,
+        "value": 1760000.0,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -8,11 +8,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 950125,
+        "value": 1197530,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 43266,
+        "value": 50525,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -64,7 +64,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 1739455,
+        "value": 2218068,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -96,7 +96,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 996206,
+        "value": 1255455,
         "compare": "<="
     }
 }

--- a/hardware/scala/elemrv_n/ElemRV.scala
+++ b/hardware/scala/elemrv_n/ElemRV.scala
@@ -23,8 +23,7 @@ import nafarr.peripherals.pinmux.{WishbonePinmux, Pinmux, PinmuxCtrl}
 object ElemRV {
   def apply(parameter: Nitrogen.Parameter) = ElemRV(parameter)
 
-  case class Parameter(boardParameter: BoardParameter)
-      extends SocParameter(boardParameter, socInterrupts = 6) {
+  case class Parameter(boardParameter: BoardParameter) extends SocParameter(boardParameter) {
     val gpio0 = GpioCtrl.Parameter(Gpio.Parameter(20), 3)
     val i2c0 = I2cControllerCtrl.Parameter.default(1)
     val i2c1 = I2cControllerCtrl.Parameter.lightweight()
@@ -34,6 +33,8 @@ object ElemRV {
     val uart0 = UartCtrl.Parameter.full()
     val uart1 = UartCtrl.Parameter.lightweight()
     val pinmux = PinmuxCtrl.Parameter(Pinmux.Parameter(20), 40, 2)
+
+    override val irqSources = Seq(gpio0, i2c0, i2c1, spi0, uart0, uart1)
   }
 
   case class ElemRV(parameter: Nitrogen.Parameter) extends Nitrogen.Nitrogen(parameter) {
@@ -75,6 +76,8 @@ object ElemRV {
       for (pin <- 0 until socParameter.pwm0.io.channels) {
         addPinmuxInput(pwm0Ctrl.io.pwm.output(pin), s"pwm0_$pin")
       }
+      pwm0Ctrl.io.pwm.syncIn := False
+      pwm0Ctrl.io.pwm.faultIn := False
 
       val spi0Ctrl = WishboneSpiController(socParameter.spi0, system.wishboneConfig)
       addPeripheralDevice(spi0Ctrl.io.bus, 0x5000, 4 kB)

--- a/manifest-nightly.xml
+++ b/manifest-nightly.xml
@@ -16,5 +16,6 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 	<project name="SpinalHDL/SpinalCrypto" path="modules/elements/SpinalCrypto" revision="f2a4ae9db5e9434c5589d0651efec8719103498e" />
 	<project name="SpinalHDL/VexiiRiscv" path="modules/elements/vexiiriscv" revision="" />
 	<project name="aesc-silicon/elements-vexriscv" path="modules/elements/vexriscv" revision="6814d54a341562beb330d407bb9898024367e447" />
-	<project name="The-OpenROAD-Project/OpenROAD-flow-scripts" path="tools/OpenROAD-flow-scripts" revision="master" />
+	<project name="aesc-silicon/OpenROAD-flow-scripts" path="tools/OpenROAD-flow-scripts" revision="ede8b54b2a6015bf2929832bee21015a833ec5f7" />
+	<project name="aesc-silicon/IHP-Open-PDK" sync-s="true" path="pdks/IHP-Open-PDK" revision="64239e24bdbe742355c141e443b4149a2af0eaf3" />
 </manifest>

--- a/manifest.xml
+++ b/manifest.xml
@@ -11,10 +11,11 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 
 	<default remote="github" sync-j="8" />
 
-	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="85e47136979eedcf3b88db0e95178ca9b10eb969" />
-	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="5b7857b8a5820a1d1d047ec3536c983b797132ba" />
+	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="6f08b034aa54313f7eaf482e4ae5b04da6baf3df" />
+	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="0a0988f3b9e79db768752ace38c58607281900fc" />
 	<project name="SpinalHDL/SpinalCrypto" path="modules/elements/SpinalCrypto" revision="f2a4ae9db5e9434c5589d0651efec8719103498e" />
 	<project name="SpinalHDL/VexiiRiscv" path="modules/elements/vexiiriscv" revision="03587f948b91f84197ecdbd958ba490977fd5671" />
 	<project name="aesc-silicon/elements-vexriscv" path="modules/elements/vexriscv" revision="6814d54a341562beb330d407bb9898024367e447" />
-	<project name="The-OpenROAD-Project/OpenROAD-flow-scripts" path="tools/OpenROAD-flow-scripts" revision="52b6f9dd8143eb72d47c2fc58fc6ce95c2165637" />
+	<project name="aesc-silicon/OpenROAD-flow-scripts" path="tools/OpenROAD-flow-scripts" revision="ede8b54b2a6015bf2929832bee21015a833ec5f7" />
+	<project name="aesc-silicon/IHP-Open-PDK" sync-s="true" path="pdks/IHP-Open-PDK" revision="64239e24bdbe742355c141e443b4149a2af0eaf3" />
 </manifest>

--- a/software/elemrv_h/bootrom/kernel.ld
+++ b/software/elemrv_h/bootrom/kernel.ld
@@ -9,7 +9,7 @@
 MEMORY
 {
 	OCRAM (xrw): ORIGIN = 0x80000000, LENGTH = 8k
-	FLASH (xr ): ORIGIN = 0xA0000000, LENGTH = 64k
+	FLASH (xr ): ORIGIN = 0xA0000000, LENGTH = 512k
 }
 stack_size = 4k;
 heap_size = 0;

--- a/software/elemrv_h/demo/kernel.ld
+++ b/software/elemrv_h/demo/kernel.ld
@@ -9,7 +9,7 @@
 MEMORY
 {
 	OCRAM (xrw): ORIGIN = 0x80000000, LENGTH = 8k
-	FLASH (xr ): ORIGIN = 0xA0000000, LENGTH = 64k
+	FLASH (xr ): ORIGIN = 0xA0010000, LENGTH = 512k
 }
 stack_size = 4k;
 heap_size = 0;

--- a/software/elemrv_h/demo/start.s
+++ b/software/elemrv_h/demo/start.s
@@ -14,13 +14,12 @@
 .extern isr_handle
 .global _head
 _head:
-	li	a0, 1
+	li	a0, 2
 	jal	gpio_set_pin
 
-	jal	_init_xip
-	jal	_init_regs
 	jal	_init_bss
 
+	# Jump to application
 	la	sp, __stack_start
 	j	_kernel
 

--- a/software/elemrv_h/gen_baremetal_container.sh
+++ b/software/elemrv_h/gen_baremetal_container.sh
@@ -4,9 +4,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FW_DIR=${BUILD_ROOT}/${SOC}/${BOARD}/firmware/
+FW_DIR=${BUILD_ROOT}/${SOC}/firmware/
 IMG_CONTAINER=${FW_DIR}/baremetal_container.img
 
 dd if=/dev/zero of=${IMG_CONTAINER} bs=32M count=1
 dd if=${FW_DIR}/bootrom/kernel.img of=${IMG_CONTAINER} conv=notrunc
 dd if=${FW_DIR}/demo/kernel.img of=${IMG_CONTAINER} seek=64 bs=1k conv=notrunc
+echo "Generated ${IMG_CONTAINER}"

--- a/software/elemrv_h/gen_zephyr_container.sh
+++ b/software/elemrv_h/gen_zephyr_container.sh
@@ -4,9 +4,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FW_DIR=${BUILD_ROOT}/${SOC}/${BOARD}/firmware/
+FW_DIR=${BUILD_ROOT}/${SOC}/firmware/
 IMG_CONTAINER=${FW_DIR}/zephyr_container.img
 
 dd if=/dev/zero of=${IMG_CONTAINER} bs=32M count=1
 dd if=${FW_DIR}/bootrom/kernel.img of=${IMG_CONTAINER} conv=notrunc
 dd if=${FW_DIR}/zephyr/zephyr/zephyr.bin of=${IMG_CONTAINER} seek=64 bs=1k conv=notrunc
+echo "Generated ${IMG_CONTAINER}"

--- a/software/elemrv_n/gen_baremetal_container.sh
+++ b/software/elemrv_n/gen_baremetal_container.sh
@@ -4,9 +4,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FW_DIR=${BUILD_ROOT}/${SOC}/${BOARD}/firmware/
+FW_DIR=${BUILD_ROOT}/${SOC}/firmware/
 IMG_CONTAINER=${FW_DIR}/baremetal_container.img
 
 dd if=/dev/zero of=${IMG_CONTAINER} bs=32M count=1
 dd if=${FW_DIR}/bootrom/kernel.img of=${IMG_CONTAINER} conv=notrunc
 dd if=${FW_DIR}/demo/kernel.img of=${IMG_CONTAINER} seek=64 bs=1k conv=notrunc
+echo "Generated ${IMG_CONTAINER}"

--- a/software/elemrv_n/gen_zephyr_container.sh
+++ b/software/elemrv_n/gen_zephyr_container.sh
@@ -4,9 +4,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FW_DIR=${BUILD_ROOT}/${SOC}/${BOARD}/firmware/
+FW_DIR=${BUILD_ROOT}/${SOC}/firmware/
 IMG_CONTAINER=${FW_DIR}/zephyr_container.img
 
 dd if=/dev/zero of=${IMG_CONTAINER} bs=32M count=1
 dd if=${FW_DIR}/bootrom/kernel.img of=${IMG_CONTAINER} conv=notrunc
 dd if=${FW_DIR}/zephyr/zephyr/zephyr.bin of=${IMG_CONTAINER} seek=64 bs=1k conv=notrunc
+echo "Generated ${IMG_CONTAINER}"


### PR DESCRIPTION
Major update to the ElemRV-H platform, switching from the legacy BMB/Wishbone interconnect to TileLink and migrating the ASIC target from IHP SG13G2 to the lower-cost SG13CMOS5L process.

- Bus migration: Replace BMB + Wishbone with TileLink throughout — CPU interconnect, OCRAM, SPI XIP, and all peripheral slave interfaces. Aligns with the VexiiRiscv ecosystem.
- Process node: Move ASIC target from SG13G2 to SG13CMOS5L. Update IO cells, power pads, die/core area, and SRAM macro placement. SRAM increased to 8 kB (two banks).
- Peripherals: Migrate GPIO, UART, I2C, PIO, PWM, Pinmux to TileLink. Add Timer, Watchdog, ESM, Syscon, and PRNG. Wire interrupt and error signals for PIO, PWM, UART, PRNG.
- Memory map: Reduce SPI flash region from 8 MB to 512 kB. Update linker scripts and boot code.
- Build system: Add SG13CMOS5L Taskfile support, fix firmware output paths to be target-independent, make Zephyr app configurable via ZEPHYR_APP variable.
- ElemRV-N: Minor fixups to address Nafarr/Zibal API changes (interrupt counting, PWM sync/fault inputs).
- Manifests: Bump Nafarr and Zibal. Pin ORFS and IHP PDK to versions with CMOS5L support.
- Docs: Update ElemRV-H spec page with system peripheral table and new interrupt sources.
