### PR TITLE
Update README/Docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,10 +2,10 @@
 ..
 .. SPDX-License-Identifier: CERN-OHL-W-2.0
 
-ElemRV - End-to-end Open-Source RISC-V MCU
-==========================================
+ElemRV - End-to-end Open-Source RISC-V MCU Platform
+====================================================
 
-This project offers an end-to-end open-source RISC-V Microcontroller, fully implemented in SpinalHDL and design to work seamlessly with the OpenROAD toolchain. This MCU is tailored to use with the IHP Open SG13G2 PDK, providing a complete open-source solution from RTL to GDSII without any reliance on proprietary software.
+ElemRV is a platform of open-source RISC-V microcontrollers, fully implemented in SpinalHDL and designed to work seamlessly with the OpenROAD toolchain. Several SoC variants are available, ranging from minimal cost-efficient cores to high-performance configurations, while sharing a common toolchain and design methodology. Each variant is tailored to work with open PDKs such as IHP SG13G2, providing a complete open-source solution from RTL to GDSII without any reliance on proprietary software.
 
 Features
 ########
@@ -17,9 +17,9 @@ Features
 
   * **Chip Layout**: Created using the OpenROAD flow.
 
-* **RISC-V**: Powered by a VexiiRiscv RISC-V CPU with the RV32IC instruction set.
+* **RISC-V**: Powered by a VexiiRiscv RISC-V CPU, with instruction set extensions tailored to each SoC variant.
 * **Zephyr RTOS**: Firmware based on Zephyr RTOS for efficient real-time operation.
-* **Memory**: Supports up to one HyperRAM chip and executes code from external SPI Flash in XIP mode.
+* **Memory**: All variants boot from external SPI Flash in XIP mode. Higher-tier SoCs add HyperRAM for additional memory.
 * **Interfaces**: Includes common low-speed interfaces such as GPIO, UART, I2C, SPI, and programmable I/Os.
 
 Layout Rendering
@@ -62,6 +62,10 @@ This project uses Taskfile as its task runner tool. You can install Taskfile usi
 - List all available tasks::
 
         task -a
+
+Most tasks accept the ``SOC`` and ``PDK`` variables to select a specific SoC variant and target PDK. For example::
+
+        task prepare SOC=ElemRV-H PDK=ihp-sg13cmos5l
 
 **Note:** By default, the X-Server is required for the `view-klayout` and `view-openroad` tasks. On headless systems, you can bypass this requirement by adding `IS_HEADLESS=true` before the task command. This is particularly useful when accessing the system via SSH, as it allows you to run the container without the need for X-Server.
 

--- a/docs/source/nonmetals/index.rst
+++ b/docs/source/nonmetals/index.rst
@@ -10,17 +10,14 @@ tier. Each platform is a strict superset of the one before it.
 Feature Overview
 ****************
 
-.. list-table::
-   :header-rows: 2
-   :stub-columns: 1
+All platforms use a VexiiRiscv CPU. Higher-tier variants add caches, branch
+prediction, and wider execution pipelines for increased performance.
 
-   * -
-     - H
-     - C
-     - N
-     - O
-     - P
-     - S
+.. list-table:: CPU
+   :header-rows: 1
+   :stub-columns: 1
+   :align: left
+
    * -
      - Hydrogen
      - Carbon
@@ -28,13 +25,6 @@ Feature Overview
      - Oxygen
      - Phosphorus
      - Sulfur
-   * - **CPU**
-     -
-     -
-     -
-     -
-     -
-     -
    * - I-Cache
      -
      - ✓
@@ -84,13 +74,22 @@ Feature Overview
      - M+U
      - M+U
      - M+U
-   * - **Memory**
-     -
-     -
-     -
-     -
-     -
-     -
+
+Every platform includes on-chip SRAM and boots from external SPI Flash in XIP
+mode. Starting with Nitrogen, HyperRAM and tightly-coupled memory are available.
+
+.. list-table:: Memory
+   :header-rows: 1
+   :stub-columns: 1
+   :align: left
+
+   * -
+     - Hydrogen
+     - Carbon
+     - Nitrogen
+     - Oxygen
+     - Phosphorus
+     - Sulfur
    * - On-chip SRAM
      - ✓
      - ✓
@@ -119,13 +118,22 @@ Feature Overview
      - ✓
      - ✓
      - ✓
-   * - **Interconnect**
-     -
-     -
-     -
-     -
-     -
-     -
+
+Simpler variants use a shared bus, while higher-tier platforms switch to a
+crossbar for better throughput.
+
+.. list-table:: Interconnect
+   :header-rows: 1
+   :stub-columns: 1
+   :align: left
+
+   * -
+     - Hydrogen
+     - Carbon
+     - Nitrogen
+     - Oxygen
+     - Phosphorus
+     - Sulfur
    * - Shared bus
      - ✓
      - ✓
@@ -140,13 +148,21 @@ Feature Overview
      - ✓
      - ✓
      - ✓
-   * - **DMA**
-     -
-     -
-     -
-     -
-     -
-     -
+
+A DMA controller is available starting with Nitrogen.
+
+.. list-table:: DMA
+   :header-rows: 1
+   :stub-columns: 1
+   :align: left
+
+   * -
+     - Hydrogen
+     - Carbon
+     - Nitrogen
+     - Oxygen
+     - Phosphorus
+     - Sulfur
    * - Channels
      -
      -
@@ -154,13 +170,21 @@ Feature Overview
      - TBD
      - TBD
      - TBD
-   * - **Interrupt Controller**
-     -
-     -
-     -
-     -
-     -
-     -
+
+All platforms include a PLIC for interrupt handling.
+
+.. list-table:: Interrupt Controller
+   :header-rows: 1
+   :stub-columns: 1
+   :align: left
+
+   * -
+     - Hydrogen
+     - Carbon
+     - Nitrogen
+     - Oxygen
+     - Phosphorus
+     - Sulfur
    * - PLIC sources
      - ✓
      - ✓
@@ -168,13 +192,22 @@ Feature Overview
      - ✓
      - ✓
      - ✓
-   * - **Debug**
-     -
-     -
-     -
-     -
-     -
-     -
+
+JTAG debug is available on every platform. Higher-tier variants add trace
+support for real-time instruction tracing.
+
+.. list-table:: Debug
+   :header-rows: 1
+   :stub-columns: 1
+   :align: left
+
+   * -
+     - Hydrogen
+     - Carbon
+     - Nitrogen
+     - Oxygen
+     - Phosphorus
+     - Sulfur
    * - JTAG
      - ✓
      - ✓
@@ -189,13 +222,22 @@ Feature Overview
      - ✓
      - ✓
      - ✓
-   * - **Power**
-     -
-     -
-     -
-     -
-     -
-     -
+
+Hydrogen and Carbon run on a single clock domain. Advanced power management
+for higher-tier platforms is planned.
+
+.. list-table:: Power
+   :header-rows: 1
+   :stub-columns: 1
+   :align: left
+
+   * -
+     - Hydrogen
+     - Carbon
+     - Nitrogen
+     - Oxygen
+     - Phosphorus
+     - Sulfur
    * - Clock domains
      - 1
      - 1
@@ -205,8 +247,9 @@ Feature Overview
      - TBD
 
 
+See the available platforms for detailed specifications and usage instructions.
+
 .. toctree::
    :maxdepth: 2
-   :caption: Platforms:
 
    elemrv_h.rst


### PR DESCRIPTION
ElemRV has grown from a single microcontroller into a platform with multiple SoC variants. This PR updates the documentation accordingly.                                                                      

**README.rst**

  - Updated title and introduction to describe ElemRV as a platform of microcontrollers ranging from minimal cost-efficient to high-performance configurations.
  - Made the Features section more generic: removed fixed instruction set (RV32IC), generalized memory description (all variants boot from SPI Flash XIP, higher-tier SoCs add HyperRAM).
  - Added documentation for SOC and PDK variables to switch between SoC variants and target PDKs.

**docs/source/nonmetals/index.rst**

  - Split the monolithic feature table into seven separate tables (CPU, Memory, Interconnect, DMA, Interrupt Controller, Debug, Power) with introductory sentences for each category.
  - Replaced short element symbols (H, C, N, ...) with full names (Hydrogen, Carbon, Nitrogen, ...) for consistent column widths across all tables.
  - Left-aligned all tables.
  - Added introductory text before the platform toctree.
