### PR TITLE
Add Report Tool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ timeout: 10800
 # Conditional logic for PRs vs Cron
 if: type IN (pull_request, cron)
 
+cache:
+  directories:
+    - $HOME/.podman-cache
+
 install:
   # Install Podman
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ script:
 
   # Prepare the project
   - CI=true IS_HEADLESS=true task install branch=${BRANCH} ${MANIFEST_SUFFIX}
+  - CI=true IS_HEADLESS=true task install-zephyr
 
   # Prepare files
   - CI=true IS_HEADLESS=true task SOC=ElemRV-H PDK=ihp-sg13cmos5l prepare

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,29 +45,41 @@ script:
   # Prepare the project
   - CI=true IS_HEADLESS=true task install branch=${BRANCH} ${MANIFEST_SUFFIX}
 
-  # Prepare FPGA files
-  - IS_HEADLESS=true task fpga:prepare
-
-  # Synthesize FPGA design
-  - IS_HEADLESS=true task fpga:synthesize
-
   # Prepare files
-  - CI=true IS_HEADLESS=true task prepare
+  - CI=true IS_HEADLESS=true task SOC=ElemRV-H PDK=ihp-sg13cmos5l prepare
+  - CI=true IS_HEADLESS=true task SOC=ElemRV-C PDK=ihp-sg13cmos5l prepare
+  - CI=true IS_HEADLESS=true task SOC=ElemRV-N PDK=ihp-sg13g2 prepare
 
   # Compile baremetal firmware
-  - CI=true IS_HEADLESS=true task baremetal:compile
+  - CI=true IS_HEADLESS=true task SOC=ElemRV-H baremetal:compile
+  - CI=true IS_HEADLESS=true task SOC=ElemRV-C baremetal:compile
+  - CI=true IS_HEADLESS=true task SOC=ElemRV-N baremetal:compile
 
+  # Prepare FPGA files
+  - CI=true IS_HEADLESS=true task SOC=ElemRV-H fpga:prepare
+  - CI=true IS_HEADLESS=true task SOC=ElemRV-C fpga:prepare
+  - CI=true IS_HEADLESS=true task SOC=ElemRV-N fpga:prepare
+
+  # TODO ElemRV-C are currently missing in Zephyr
   # Compile Zephyr firmware
-  - CI=true IS_HEADLESS=true task zephyr:compile
+  - CI=true IS_HEADLESS=true task SOC=ElemRV-H zephyr:compile
+  #- CI=true IS_HEADLESS=true task SOC=ElemRV-C zephyr:compile
+  - CI=true IS_HEADLESS=true task SOC=ElemRV-N zephyr:compile
 
+  # Synthesize FPGA design
+  - CI=true IS_HEADLESS=true task SOC=ElemRV-H fpga:synthesize
+  - CI=true IS_HEADLESS=true task SOC=ElemRV-C fpga:synthesize
+  - CI=true IS_HEADLESS=true task SOC=ElemRV-N fpga:synthesize
+
+  # TODO Full RTL to GDS flow takes too long for travis
   # Generate layout
-  - CI=true IS_HEADLESS=true task layout
+  #- CI=true IS_HEADLESS=true task SOC=ElemRV-H PDK=ihp-sg13cmos5l layout
 
   # Add metal fill
-  - CI=true IS_HEADLESS=true task filler
+  #- CI=true IS_HEADLESS=true task SOC=ElemRV-H PDK=ihp-sg13cmos5l filler
 
   # Run maximal DRC
-  - CI=true IS_HEADLESS=true task run-drc
+  #- CI=true IS_HEADLESS=true task SOC=ElemRV-H PDK=ihp-sg13cmos5l run-drc
 
 notifications:
   email:

--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,7 @@ This project uses Taskfile as its task runner tool. You can install Taskfile usi
 - Set up the project::
 
         task install
+        task install-zephyr
 
 - List all available tasks::
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -141,11 +141,15 @@ tasks:
       - task: _project-prepare
       - task: _build-container
       - task: repo-sync
-      - task: west-init
-      - task: west-update
     vars:
       branch: "main"
       manifest_suffix: ""
+
+  install-zephyr:
+    desc: Initializes the Zephyr workspace and fetches all Zephyr dependencies.
+    cmds:
+      - task: west-init
+      - task: west-update
 
   prepare:
     desc: Generates all necessary source files and metadata for chip layout creation.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -112,7 +112,22 @@ tasks:
 
   _build-container:
     cmds:
-      - venv/bin/podman-compose {{if .CI}}--podman-pull-args=-q{{end}} pull
+      - |
+        {{if .CI -}}
+        CONTAINER_IMAGE=$(grep 'image:' podman-compose-headless.yml | awk '{print $2}')
+        CACHE_DIR="$HOME/.podman-cache"
+        CACHE_TAG=$(echo "$CONTAINER_IMAGE" | sed 's/[\/:]/-/g')
+        CACHE_FILE="$CACHE_DIR/${CACHE_TAG}.tar"
+        mkdir -p "$CACHE_DIR"
+        if [ -f "$CACHE_FILE" ]; then
+          podman load -q -i "$CACHE_FILE"
+        else
+          podman pull -q "$CONTAINER_IMAGE"
+          podman save -o "$CACHE_FILE" "$CONTAINER_IMAGE"
+        fi
+        {{- else -}}
+        venv/bin/podman-compose pull
+        {{- end}}
 
   repo-sync:
     desc: Downloads and synchronizes all required dependencies.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -15,9 +15,10 @@ Install system dependencies and Taskfile::
 Set Up the Project
 ******************
 
-Run the install task to download and configure all dependencies::
+Run the install tasks to download and configure all dependencies::
 
     task install
+    task install-zephyr
 
 To list all available tasks::
 

--- a/hardware/scala/elemrv_c/ECPIX5/ECPIX5.scala
+++ b/hardware/scala/elemrv_c/ECPIX5/ECPIX5.scala
@@ -9,7 +9,6 @@ import spinal.core.sim._
 import spinal.lib._
 import spinal.lib.bus.tilelink.{BusParameter => TileLinkParameter}
 
-import nafarr.memory.ocram.ihp.sg13g2.TileLinkIhpOnChipRam
 import nafarr.system.reset._
 import nafarr.system.reset.ResetControllerCtrl._
 import nafarr.system.clock._
@@ -116,10 +115,6 @@ case class ECPIX5Top() extends Component {
         List("system", "debug")
       )
       clockCtrl
-    },
-    onChipRamLogic = (p: TileLinkParameter, size: BigInt) => {
-      val ram = TileLinkIhpOnChipRam.OnePort(p, size.toInt)
-      (ram, ram.io.bus)
     }
   )
 

--- a/hardware/scala/elemrv_c/SG13CMOS5L/SG13CMOS5L.scala
+++ b/hardware/scala/elemrv_c/SG13CMOS5L/SG13CMOS5L.scala
@@ -234,6 +234,11 @@ object SG13CMOS5LGenerate extends ElementsApp {
   chip.pdnRingWidth = 30.0
   chip.pdnRingSpace = 5.0
   chip.generate
+
+  val reporter = ReportTools.Report(report.toplevel.soc, elementsConfig)
+  reporter.extractPads(report.toplevel.io, report.toplevel.power)
+  reporter.generateAll()
+  reporter.generateJson()
 }
 
 object SG13CMOS5LSimulate extends ElementsApp {

--- a/hardware/scala/elemrv_h/ECPIX5/ECPIX5.scala
+++ b/hardware/scala/elemrv_h/ECPIX5/ECPIX5.scala
@@ -9,7 +9,6 @@ import spinal.core.sim._
 import spinal.lib._
 import spinal.lib.bus.tilelink.{BusParameter => TileLinkParameter}
 
-import nafarr.memory.ocram.ihp.sg13g2.TileLinkIhpOnChipRam
 import nafarr.system.reset._
 import nafarr.system.reset.ResetControllerCtrl._
 import nafarr.system.clock._
@@ -115,10 +114,6 @@ case class ECPIX5Top() extends Component {
         List("system", "debug")
       )
       clockCtrl
-    },
-    onChipRamLogic = (p: TileLinkParameter, size: BigInt) => {
-      val ram = TileLinkIhpOnChipRam.OnePort(p, size.toInt)
-      (ram, ram.io.bus)
     }
   )
 

--- a/hardware/scala/elemrv_h/SG13CMOS5L/SG13CMOS5L.scala
+++ b/hardware/scala/elemrv_h/SG13CMOS5L/SG13CMOS5L.scala
@@ -225,6 +225,11 @@ object SG13CMOS5LGenerate extends ElementsApp {
   chip.pdnRingWidth = 30.0
   chip.pdnRingSpace = 5.0
   chip.generate
+
+  val reporter = ReportTools.Report(report.toplevel.soc, elementsConfig)
+  reporter.extractPads(report.toplevel.io, report.toplevel.power)
+  reporter.generateAll()
+  reporter.generateJson()
 }
 
 object SG13CMOS5LSimulate extends ElementsApp {

--- a/manifest.xml
+++ b/manifest.xml
@@ -17,5 +17,5 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 	<project name="SpinalHDL/VexiiRiscv" path="modules/elements/vexiiriscv" revision="03587f948b91f84197ecdbd958ba490977fd5671" />
 	<project name="aesc-silicon/elements-vexriscv" path="modules/elements/vexriscv" revision="6814d54a341562beb330d407bb9898024367e447" />
 	<project name="aesc-silicon/OpenROAD-flow-scripts" path="tools/OpenROAD-flow-scripts" revision="ede8b54b2a6015bf2929832bee21015a833ec5f7" />
-	<project name="aesc-silicon/IHP-Open-PDK" sync-s="true" path="pdks/IHP-Open-PDK" revision="64239e24bdbe742355c141e443b4149a2af0eaf3" />
+	<project name="aesc-silicon/IHP-Open-PDK" sync-s="true" path="pdks/IHP-Open-PDK" revision="5a64253fe0c1d816b8d06857d2f31e35303a5bae" />
 </manifest>

--- a/manifest.xml
+++ b/manifest.xml
@@ -11,8 +11,8 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 
 	<default remote="github" sync-j="8" />
 
-	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="c1193c4a048bcd1dbee788271a817a57b840da54" />
-	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="7165339d3651035d105034535678a09f4e3cad3b" />
+	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="fe097a0d2a26bc4c4d8472d7b3093f82291fa32d" />
+	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="e2d3a60339fcbf6951c8db21d28220e8e9f41cf2" />
 	<project name="SpinalHDL/SpinalCrypto" path="modules/elements/SpinalCrypto" revision="f2a4ae9db5e9434c5589d0651efec8719103498e" />
 	<project name="SpinalHDL/VexiiRiscv" path="modules/elements/vexiiriscv" revision="03587f948b91f84197ecdbd958ba490977fd5671" />
 	<project name="aesc-silicon/elements-vexriscv" path="modules/elements/vexriscv" revision="6814d54a341562beb330d407bb9898024367e447" />


### PR DESCRIPTION
Add generated reports to both ASIC targets for ElemRV-H and -C. Those reports include tables with error, interrupt and pinmux options. Additionally, it generates a JSON with all information and pad locations.

Fix the memory instance for both FPGA targets and update travis.