### PR TITLE
Clock controller and bootrom updates

### DIFF
--- a/hardware/scala/elemrv_c/ECPIX5/ECPIX5.scala
+++ b/hardware/scala/elemrv_c/ECPIX5/ECPIX5.scala
@@ -93,7 +93,7 @@ case class ECPIX5Top() extends Component {
     ClockParameter("system", 50 MHz, "system"),
     ClockParameter("debug", 12.5 MHz, "debug", synchronousWith = "system")
   )
-  val kitParameter = KitParameter(resets, clocks)
+  val kitParameter = KitParameter(resets, clocks, inputClock)
   val boardParameter = ECPIX5.Parameter(kitParameter, ECPIX5.SystemClock.frequency)
   val socParameter = ElemRV.Parameter(boardParameter)
   val parameter = Carbon.Parameter(

--- a/hardware/scala/elemrv_c/SG13CMOS5L/SG13CMOS5L.scala
+++ b/hardware/scala/elemrv_c/SG13CMOS5L/SG13CMOS5L.scala
@@ -80,7 +80,7 @@ case class SG13CMOS5LTop() extends Component {
     ClockParameter("system", inputClock.frequency, "system"),
     ClockParameter("debug", inputClock.frequency / 4, "debug", synchronousWith = "system")
   )
-  val kitParameter = KitParameter(resets, clocks)
+  val kitParameter = KitParameter(resets, clocks, inputClock)
   val boardParameter = ElemRVFlask.Carbon.Parameter(kitParameter)
   val socParameter = ElemRV.Parameter(boardParameter)
   val parameter = Carbon.Parameter(

--- a/hardware/scala/elemrv_h/ECPIX5/ECPIX5.scala
+++ b/hardware/scala/elemrv_h/ECPIX5/ECPIX5.scala
@@ -93,7 +93,7 @@ case class ECPIX5Top() extends Component {
     ClockParameter("system", 50 MHz, "system"),
     ClockParameter("debug", 12.5 MHz, "debug", synchronousWith = "system")
   )
-  val kitParameter = KitParameter(resets, clocks)
+  val kitParameter = KitParameter(resets, clocks, inputClock)
   val boardParameter = ECPIX5.Parameter(kitParameter, ECPIX5.SystemClock.frequency)
   val socParameter = ElemRV.Parameter(boardParameter)
   val parameter = Hydrogen.Parameter(

--- a/hardware/scala/elemrv_h/SG13CMOS5L/SG13CMOS5L.scala
+++ b/hardware/scala/elemrv_h/SG13CMOS5L/SG13CMOS5L.scala
@@ -80,7 +80,7 @@ case class SG13CMOS5LTop() extends Component {
     ClockParameter("system", inputClock.frequency, "system"),
     ClockParameter("debug", inputClock.frequency / 4, "debug", synchronousWith = "system")
   )
-  val kitParameter = KitParameter(resets, clocks)
+  val kitParameter = KitParameter(resets, clocks, inputClock)
   val boardParameter = ElemRVFlask.Hydrogen.Parameter(kitParameter)
   val socParameter = ElemRV.Parameter(boardParameter)
   val parameter = Hydrogen.Parameter(

--- a/hardware/scala/elemrv_h/SG13CMOS5L/SG13CMOS5L.scala
+++ b/hardware/scala/elemrv_h/SG13CMOS5L/SG13CMOS5L.scala
@@ -201,9 +201,9 @@ object SG13CMOS5LGenerate extends ElementsApp {
   )
   chip.addMacro(
     report.toplevel.soc.system.onChipRam.ctrl.asInstanceOf[TileLinkIhpOnChipRam.OnePort].rams(1),
-    1137.92,
-    409.12,
-    "MX",
+    434.08,
+    1240.0,
+    "R0",
     depth = 3
   )
 

--- a/hardware/scala/elemrv_n/ECPIX5/ECPIX5.scala
+++ b/hardware/scala/elemrv_n/ECPIX5/ECPIX5.scala
@@ -137,7 +137,7 @@ case class ECPIX5Top() extends Component {
     (8 MB, true),
     (8 MB, true)
   )
-  val kitParameter = KitParameter(resets, clocks)
+  val kitParameter = KitParameter(resets, clocks, inputClock)
   val boardParameter = ECPIX5.Parameter(kitParameter, ECPIX5.SystemClock.frequency)
   val socParameter = ElemRV.Parameter(boardParameter)
   val parameter = Nitrogen.Parameter(

--- a/hardware/scala/elemrv_n/SG13G2/SG13G2.scala
+++ b/hardware/scala/elemrv_n/SG13G2/SG13G2.scala
@@ -126,7 +126,7 @@ case class SG13G2Top() extends Component {
     (8 MB, true),
     (8 MB, true)
   )
-  val kitParameter = KitParameter(resets, clocks)
+  val kitParameter = KitParameter(resets, clocks, inputClock)
   val boardParameter = ElemRVBoard.Parameter(kitParameter)
   val socParameter = ElemRV.Parameter(boardParameter)
   val parameter = Nitrogen.Parameter(

--- a/manifest.xml
+++ b/manifest.xml
@@ -11,8 +11,8 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 
 	<default remote="github" sync-j="8" />
 
-	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="fe097a0d2a26bc4c4d8472d7b3093f82291fa32d" />
-	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="e2d3a60339fcbf6951c8db21d28220e8e9f41cf2" />
+	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="5bc81ab38a68ddf0c9cf806596cdba7694f80d62" />
+	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="334661d9571129e822c586232479af1b8b4eaae2" />
 	<project name="SpinalHDL/SpinalCrypto" path="modules/elements/SpinalCrypto" revision="f2a4ae9db5e9434c5589d0651efec8719103498e" />
 	<project name="SpinalHDL/VexiiRiscv" path="modules/elements/vexiiriscv" revision="03587f948b91f84197ecdbd958ba490977fd5671" />
 	<project name="aesc-silicon/elements-vexriscv" path="modules/elements/vexriscv" revision="6814d54a341562beb330d407bb9898024367e447" />

--- a/software/elemrv_h/bootrom/kernel.ld
+++ b/software/elemrv_h/bootrom/kernel.ld
@@ -9,7 +9,7 @@
 MEMORY
 {
 	OCRAM (xrw): ORIGIN = 0x80000000, LENGTH = 8k
-	FLASH (xr ): ORIGIN = 0xA0000000, LENGTH = 512k
+	FLASH (xr ): ORIGIN = 0xA0000000, LENGTH = 4k
 }
 stack_size = 4k;
 heap_size = 0;

--- a/software/elemrv_h/bootrom/start.s
+++ b/software/elemrv_h/bootrom/start.s
@@ -20,7 +20,7 @@ _head:
 	jal	gpio_set_pin
 
 	# Jump to application
-	li	ra, 0xa0010000
+	li	ra, 0xa0001000
 	ret
 
 _init_regs:

--- a/software/elemrv_h/demo/kernel.ld
+++ b/software/elemrv_h/demo/kernel.ld
@@ -9,7 +9,7 @@
 MEMORY
 {
 	OCRAM (xrw): ORIGIN = 0x80000000, LENGTH = 8k
-	FLASH (xr ): ORIGIN = 0xA0010000, LENGTH = 512k
+	FLASH (xr ): ORIGIN = 0xA0001000, LENGTH = 512k
 }
 stack_size = 4k;
 heap_size = 0;

--- a/software/elemrv_h/gen_baremetal_container.sh
+++ b/software/elemrv_h/gen_baremetal_container.sh
@@ -9,5 +9,5 @@ IMG_CONTAINER=${FW_DIR}/baremetal_container.img
 
 dd if=/dev/zero of=${IMG_CONTAINER} bs=32M count=1
 dd if=${FW_DIR}/bootrom/kernel.img of=${IMG_CONTAINER} conv=notrunc
-dd if=${FW_DIR}/demo/kernel.img of=${IMG_CONTAINER} seek=64 bs=1k conv=notrunc
+dd if=${FW_DIR}/demo/kernel.img of=${IMG_CONTAINER} seek=4 bs=1k conv=notrunc
 echo "Generated ${IMG_CONTAINER}"

--- a/software/elemrv_h/gen_zephyr_container.sh
+++ b/software/elemrv_h/gen_zephyr_container.sh
@@ -9,5 +9,5 @@ IMG_CONTAINER=${FW_DIR}/zephyr_container.img
 
 dd if=/dev/zero of=${IMG_CONTAINER} bs=32M count=1
 dd if=${FW_DIR}/bootrom/kernel.img of=${IMG_CONTAINER} conv=notrunc
-dd if=${FW_DIR}/zephyr/zephyr/zephyr.bin of=${IMG_CONTAINER} seek=64 bs=1k conv=notrunc
+dd if=${FW_DIR}/zephyr/zephyr/zephyr.bin of=${IMG_CONTAINER} seek=4 bs=1k conv=notrunc
 echo "Generated ${IMG_CONTAINER}"


### PR DESCRIPTION
**manifest: Update Zibal and Nafarr (c0791cc)**
Bumps the Zibal and Nafarr revisions to pull in the ClockController rework, which exposes each clock domain's multiplier/divider so software can compute domain rates from the reference clock at runtime.

**hardware: Add inputClock to KitParameter (3c9ec1a)**
Threads the board input clock through KitParameter(resets, clocks, inputClock) so the internal ClockController has the reference frequency it needs to compute the per-domain multiplier/divider. Applied across
  all SoC/board targets (elemrv_c/h/n × ECPIX5/SG13CMOS5L/SG13G2).

**hardware: elemrv_h: SG13CMOS5L: Move second SRAM macro (9e641ea)**
The second on-chip SRAM macro was sitting in front of the clock/reset input pads, creating a routing/placement hot spot. Relocating it relaxes that area.

**software: elemrv_h: Reduce bootrom size (a30b9b0)**
The Hydrogen bootrom now only enables SPI quad mode, so its reserved region is reduced to 4 kB (one flash erase sector), freeing flash for the application.