### PR TITLE
Add Renode emulation and Verilator co-simulation for ElemRV (H + C)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -175,6 +175,28 @@ tasks:
     cmds:
       - task: lib-view-simulation
 
+  emulate:
+    desc: Boots a bare-metal binary in Renode (functional emulation). Add 'bin=path/to/app.bin'.
+    cmds:
+      - task: lib-emulate
+
+  emulate-gui:
+    desc: Like 'emulate' but launches the full Renode GUI (monitor window). Add 'bin=path/to/app.bin'.
+    cmds:
+      - task: lib-emulate-gui
+
+  cosim:
+    desc: Boots a binary in Renode co-simulating the real GPIO RTL (rebuilds the co-sim library first). Add 'bin=path/to/app.bin'.
+    cmds:
+      - task: lib-cosim-build
+      - task: lib-cosim
+
+  cosim-gui:
+    desc: Like 'cosim' but launches the full Renode GUI (monitor window).
+    cmds:
+      - task: lib-cosim-build
+      - task: lib-cosim-gui
+
   layout:
     desc: Creates the physical layout of the chip.
     cmds:

--- a/docs/source/flows/chip.rst
+++ b/docs/source/flows/chip.rst
@@ -89,10 +89,6 @@ Scan the build logs for warnings and errors after any flow step::
 Known Issues
 ************
 
-- **M2.d errors** - OpenROAD generates excessively small segments on M2 when
-  connecting Via1 to Via2.
-- **Fill errors** - ``AFil.g2`` and ``MxFil.h`` may fail when there is
-  insufficient metal fill in the chip core area.
 - **X server** - If ``view-klayout`` or ``view-openroad`` fails with an X
   server permission error, grant access with::
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -68,5 +68,6 @@ Content
 
    installation.rst
    flows/index.rst
+   virtual-prototyping/index.rst
    nonmetals/index.rst
    hardware/index.rst

--- a/docs/source/virtual-prototyping/co-simulation.rst
+++ b/docs/source/virtual-prototyping/co-simulation.rst
@@ -1,0 +1,58 @@
+Co-simulation
+#############
+
+Co-simulation is a hybrid of :doc:`emulation` and :doc:`rtl-simulation`: the CPU,
+interconnect, on-chip RAM, flash, and a few timing-sensitive blocks (UART
+console, PLIC, machine timer) stay as fast Renode functional models, while the
+**peripherals run as real Verilated RTL**. This lets you develop and validate a
+driver against the actual hardware description without paying for a full-SoC RTL
+simulation - Renode's system bus simply routes each peripheral's address window
+to its Verilated model.
+
+Each co-simulated peripheral is one Verilated library built from a ``TileLink*``
+module of the generated SoC netlist. The shared C++ integration (a TileLink-UL
+bus driver and a generic entry point) lives in Zibal under
+``hardware/renode/cosim/``; the platform wiring is
+``hardware/scala/<soc>/<soc>_cosim.repl``.
+
+Building
+********
+
+Co-simulation requires the generated netlist (run the relevant flow's
+``prepare``/``generate`` step first) and the
+``renode-verilator-integration`` checkout provided by the manifest. Verilate and
+compile one library per peripheral with::
+
+    task cosim-build SOC=ElemRV-H PDK=ihp-sg13cmos5l
+
+The libraries are produced under ``build/<SOC>/<board>/cosim/<peripheral>/``.
+
+Running
+*******
+
+``cosim`` rebuilds the libraries (incrementally - unchanged peripherals are a
+no-op) and boots the firmware::
+
+    task cosim SOC=ElemRV-H PDK=ihp-sg13cmos5l
+
+For the full Renode GUI::
+
+    task cosim-gui SOC=ElemRV-H PDK=ihp-sg13cmos5l
+
+The UART console (GUI window and host TCP socket on port 3456) works exactly as
+in :doc:`emulation`.
+
+When to use
+***********
+
+- Validating a peripheral driver against the real RTL with a fast boot.
+- Catching driver/RTL mismatches that a functional model would hide.
+
+Notes
+*****
+
+- Only peripherals are Verilated; the CPU and bus remain functional, so this is
+  not a substitute for full-SoC cycle accuracy (:doc:`rtl-simulation`).
+- ``uart0``, the PLIC, and the machine timer are intentionally kept functional.
+- The netlist already encodes each SoC's parameters, so no Verilog is generated
+  or committed - co-simulation consumes the build artifact directly.

--- a/docs/source/virtual-prototyping/emulation.rst
+++ b/docs/source/virtual-prototyping/emulation.rst
@@ -1,0 +1,50 @@
+Emulation
+#########
+
+Emulation runs the platform in `Renode <https://renode.io>`_ using fast
+*functional models* of the CPU and peripherals - no RTL is involved. It boots a
+firmware image in a fraction of a second and runs at near real-time, which makes
+it the tool of choice for software bring-up and rapid iteration.
+
+The functional peripheral models live in Nafarr next to their SpinalHDL sources
+(``*.cs`` files alongside the ``*.scala``); the platform wiring is described by
+``hardware/scala/<soc>/<soc>_emul.repl`` and the boot script
+``<soc>_emul.resc``.
+
+Running
+*******
+
+Boot the platform's firmware image headless (console in the terminal)::
+
+    task emulate SOC=ElemRV-H PDK=ihp-sg13cmos5l
+
+To launch the full Renode GUI (monitor window plus peripheral analyzers, e.g. an
+LED widget)::
+
+    task emulate-gui SOC=ElemRV-H PDK=ihp-sg13cmos5l
+
+The firmware image is taken from ``build/<SOC>/firmware/`` - build it with the
+:doc:`../flows/firmware` flow first.
+
+Console and I/O
+***************
+
+UART0 is exposed both as a Renode analyzer window (GUI) and as a TCP socket on
+port 3456, which podman-compose publishes to the host. Connect from the host
+with::
+
+    telnet localhost 3456
+
+Typing into either endpoint feeds the UART receiver. GPIO output changes are
+written to the Renode log, so pin activity is visible even without the GUI.
+
+When to use
+***********
+
+- Day-to-day firmware development and debugging (GDB, scripting, fast reboots).
+- Bring-up that does not depend on exact hardware timing.
+
+Because the peripherals are hand-written functional models, behaviour is only as
+accurate as the model. To run software against the **real** peripheral RTL while
+keeping this speed, use :doc:`co-simulation`; for full cycle accuracy use
+:doc:`rtl-simulation`.

--- a/docs/source/virtual-prototyping/index.rst
+++ b/docs/source/virtual-prototyping/index.rst
@@ -1,0 +1,46 @@
+Virtual Prototyping
+###################
+
+Virtual prototyping runs an ElemRV platform **without physical hardware**. It is
+how you develop and debug software, and verify the RTL, long before an FPGA
+bitstream or a tape-out exists.
+
+ElemRV offers three approaches that trade simulation accuracy for speed:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 18 30 30
+
+   * - Approach
+     - Tool
+     - What runs
+     - Use it for
+   * - :doc:`rtl-simulation`
+     - Verilator
+     - The full SoC as cycle-accurate RTL, with waveforms.
+     - Verifying the hardware itself.
+   * - :doc:`emulation`
+     - Renode
+     - Fast functional models of the CPU and peripherals (no RTL).
+     - Rapid software bring-up and iteration.
+   * - :doc:`co-simulation`
+     - Renode + Verilator
+     - Functional CPU plus the real peripheral RTL.
+     - Running software against actual peripheral hardware, at near-emulation speed.
+
+Pick **emulation** for the fast software loop, **co-simulation** to validate a
+driver against the real peripheral RTL while keeping that speed, and **RTL
+simulation** when you need full cycle accuracy and waveforms of the whole SoC.
+
+All three are driven by `Taskfile <https://taskfile.dev>`_ inside the container
+and select the platform with ``SOC`` and ``PDK`` (see :doc:`../installation`),
+for example::
+
+    task emulate SOC=ElemRV-H PDK=ihp-sg13cmos5l
+
+.. toctree::
+   :maxdepth: 2
+
+   rtl-simulation.rst
+   emulation.rst
+   co-simulation.rst

--- a/docs/source/virtual-prototyping/rtl-simulation.rst
+++ b/docs/source/virtual-prototyping/rtl-simulation.rst
@@ -1,0 +1,37 @@
+RTL Simulation
+##############
+
+RTL simulation runs the **complete SoC netlist** in `Verilator
+<https://www.veripool.org/verilator/>`_, cycle by cycle. It is the most accurate
+way to run the design: every clock edge of the real RTL is evaluated, and the
+run can be inspected as waveforms. It is correspondingly the slowest approach,
+and is aimed at verifying the *hardware* rather than iterating on software.
+
+Running
+*******
+
+To simulate the configured platform::
+
+    task simulate SOC=ElemRV-H PDK=ihp-sg13cmos5l
+
+By default the simulation runs to completion. Limit it to a fixed duration in
+milliseconds with ``duration``::
+
+    task simulate SOC=ElemRV-H PDK=ihp-sg13cmos5l duration=100
+
+Waveforms
+*********
+
+Open the recorded waveforms in GTKWave after a run::
+
+    task view-simulation SOC=ElemRV-H PDK=ihp-sg13cmos5l
+
+When to use
+***********
+
+- Verifying RTL behaviour and exact cycle-level timing of the whole SoC.
+- Debugging hardware issues that require signal-level visibility.
+
+For software development prefer :doc:`emulation` (much faster), and to exercise
+a driver against a single peripheral's real RTL without simulating the entire
+chip, use :doc:`co-simulation`.

--- a/hardware/scala/elemrv_c/elemrv_c_cosim.repl
+++ b/hardware/scala/elemrv_c/elemrv_c_cosim.repl
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+// ElemRV-C co-simulation platform.
+// All I/O + system peripherals are the *real* Verilated TileLink RTL; CPU, interconnect, OCRAM,
+// flash, plus uart0 (console), plic and mtimer (interrupt timing) stay functional for speed.
+// Each co-simulated peripheral is its own Verilated library (build/<SOC>/<board>/cosim/<name>/libVtop.so);
+// the .resc binds the SimulationFilePath for each. cosim->Renode signal 0 = io_interrupt, 1 = io_error.
+
+// CPU: VexiiRiscv RV32IMC + Zicsr, modeled as a generic RISC-V 32-bit core.
+cpu: CPU.RiscV32 @ sysbus
+    cpuType: "rv32imc_zicsr"
+    timeProvider: empty
+    privilegeArchitecture: PrivilegeArchitecture.Priv1_10
+
+// On-chip RAM: 8 KB @ 0x80000000
+ram: Memory.MappedMemory @ sysbus 0x80000000
+    size: 0x00002000
+
+// SPI XIP flash @ 0xA0000000 (reset/boot region)
+flash: Memory.MappedMemory @ sysbus 0xA0000000
+    size: 0x02000000
+
+// Machine timer (mtime/mtimecmp) @ 0xF0020000 - drives the CPU MTIP line (cause 7). FUNCTIONAL.
+mtimer: Timers.MachineTimerCtrl @ sysbus 0xF0020000
+    frequency: 50000000
+    -> cpu@7
+
+// PLIC @ 0xF0800000 - output context 0 -> CPU external-interrupt line (cause 11). FUNCTIONAL.
+// Sources match soc.h IRQ numbers: gpio0=3, i2c0=4, pio0=5, pwm0=6, uart0=7, watchdog=1.
+plic: IRQControllers.PlicCtrl @ sysbus 0xF0800000
+    0 -> cpu@11
+    numberOfSources: 31
+
+// UART0 @ 0xF0004000 - kept FUNCTIONAL so the Renode console/PTY works; IRQ is PLIC source 7.
+uart0: UART.UartCtrl @ sysbus 0xF0004000
+    IRQ -> plic@7
+
+// SPI XIP config bus @ 0xF0025000 - kept FUNCTIONAL (multi-bus controller, not a single TL slave).
+spiXipCfg: Miscellaneous.SpiXipControllerCtrl @ sysbus 0xF0025000
+
+// ---------------------------------------------------------------------------
+// Co-simulated peripherals (real Verilated RTL). signal 0 = io_interrupt, 1 = io_error.
+// ---------------------------------------------------------------------------
+
+// GPIO0 @ 0xF0000000 (TileLinkGpio) - IRQ -> PLIC source 3.
+gpio0: CoSimulated.CoSimulatedPeripheral @ sysbus <0xF0000000, +0x1000>
+    frequency: 50000000
+    limitBuffer: 1000000
+    timeout: 10000
+    0 -> plic@3
+    cosimToRenodeSignalRange: <0, +1>
+
+// I2C0 @ 0xF0001000 (TileLinkI2cController) - IRQ -> PLIC source 4.
+i2c0: CoSimulated.CoSimulatedPeripheral @ sysbus <0xF0001000, +0x1000>
+    frequency: 50000000
+    limitBuffer: 1000000
+    timeout: 10000
+    0 -> plic@4
+    cosimToRenodeSignalRange: <0, +1>
+
+// PIO0 @ 0xF0002000 (TileLinkPio) - IRQ -> PLIC source 5; signal 1 = error (unrouted).
+pio0: CoSimulated.CoSimulatedPeripheral @ sysbus <0xF0002000, +0x1000>
+    frequency: 50000000
+    limitBuffer: 1000000
+    timeout: 10000
+    0 -> plic@5
+    cosimToRenodeSignalRange: <0, +2>
+
+// PWM0 @ 0xF0003000 (TileLinkPwm) - IRQ -> PLIC source 6; signal 1 = error (unrouted).
+pwm0: CoSimulated.CoSimulatedPeripheral @ sysbus <0xF0003000, +0x1000>
+    frequency: 50000000
+    limitBuffer: 1000000
+    timeout: 10000
+    0 -> plic@6
+    cosimToRenodeSignalRange: <0, +2>
+
+// PRNG @ 0xF0005000 (TileLinkPrng) - signal 0 = error (unrouted, no PLIC IRQ).
+prng: CoSimulated.CoSimulatedPeripheral @ sysbus <0xF0005000, +0x1000>
+    frequency: 50000000
+    limitBuffer: 1000000
+    timeout: 10000
+    cosimToRenodeSignalRange: <0, +1>
+
+// Pinmux @ 0xF0010000 (TileLinkPinmux) - no interrupt/error.
+pinmux: CoSimulated.CoSimulatedPeripheral @ sysbus <0xF0010000, +0x1000>
+    frequency: 50000000
+    limitBuffer: 1000000
+    timeout: 10000
+
+// Reset controller @ 0xF0021000 (TileLinkResetController) - no interrupt/error.
+resetCtrl: CoSimulated.CoSimulatedPeripheral @ sysbus <0xF0021000, +0x1000>
+    frequency: 50000000
+    limitBuffer: 1000000
+    timeout: 10000
+
+// Clock controller @ 0xF0022000 (TileLinkClockController) - no interrupt/error.
+clockCtrl: CoSimulated.CoSimulatedPeripheral @ sysbus <0xF0022000, +0x1000>
+    frequency: 50000000
+    limitBuffer: 1000000
+    timeout: 10000
+
+// Syscon @ 0xF0023000 (TileLinkSyscon) - no interrupt/error.
+syscon: CoSimulated.CoSimulatedPeripheral @ sysbus <0xF0023000, +0x1000>
+    frequency: 50000000
+    limitBuffer: 1000000
+    timeout: 10000
+
+// Watchdog @ 0xF0027000 (TileLinkWatchdog) - IRQ -> PLIC source 1; signal 1 = error (unrouted).
+watchdog: CoSimulated.CoSimulatedPeripheral @ sysbus <0xF0027000, +0x1000>
+    frequency: 50000000
+    limitBuffer: 1000000
+    timeout: 10000
+    0 -> plic@1
+    cosimToRenodeSignalRange: <0, +2>
+
+// ESM @ 0xF0028000 (TileLinkEsm) - register RTL only; its non-standard signal outputs
+// (io_infoInterrupt/io_warnInterrupt/io_errorSignal) are not surfaced.
+esm: CoSimulated.CoSimulatedPeripheral @ sysbus <0xF0028000, +0x1000>
+    frequency: 50000000
+    limitBuffer: 1000000
+    timeout: 10000

--- a/hardware/scala/elemrv_c/elemrv_c_cosim.resc
+++ b/hardware/scala/elemrv_c/elemrv_c_cosim.resc
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2026 aesc silicon
+#
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+
+:name: ElemRV-C (co-simulation)
+:description: Boots a binary with all peripherals as Verilated TileLink RTL; CPU/UART/PLIC/mtimer functional.
+
+# Application binary and the directory holding the per-peripheral co-sim libraries
+# (built by 'task cosim-build' -> <cosimdir>/<name>/libVtop.so).
+$bin ?= @build/app.bin
+$cosimdir ?= @build/ElemRV-C/SG13CMOS5L/cosim
+
+# Functional peripheral models that stay in Renode (the rest are co-simulated RTL).
+i @modules/elements/nafarr/hardware/scala/nafarr/peripherals/com/uart/UartCtrl.cs
+i @modules/elements/nafarr/hardware/scala/nafarr/system/mtimer/MachineTimerCtrl.cs
+i @modules/elements/nafarr/hardware/scala/nafarr/system/plic/PlicCtrl.cs
+i @modules/elements/nafarr/hardware/scala/nafarr/memory/spi/SpiXipControllerCtrl.cs
+
+mach create "elemrv_c_cosim"
+machine LoadPlatformDescription @hardware/scala/elemrv_c/elemrv_c_cosim.repl
+
+# Bind each co-simulated peripheral to its Verilated library.
+gpio0     SimulationFilePathLinux $cosimdir/gpio0/libVtop.so
+i2c0      SimulationFilePathLinux $cosimdir/i2c0/libVtop.so
+pio0      SimulationFilePathLinux $cosimdir/pio0/libVtop.so
+pwm0      SimulationFilePathLinux $cosimdir/pwm0/libVtop.so
+prng      SimulationFilePathLinux $cosimdir/prng/libVtop.so
+pinmux    SimulationFilePathLinux $cosimdir/pinmux/libVtop.so
+resetCtrl SimulationFilePathLinux $cosimdir/resetCtrl/libVtop.so
+clockCtrl SimulationFilePathLinux $cosimdir/clockCtrl/libVtop.so
+syscon    SimulationFilePathLinux $cosimdir/syscon/libVtop.so
+watchdog  SimulationFilePathLinux $cosimdir/watchdog/libVtop.so
+esm       SimulationFilePathLinux $cosimdir/esm/libVtop.so
+
+# Boot from XIP flash (same flow as elemrv_c_emul.resc).
+sysbus LoadBinary $bin 0xA0000000
+cpu PC 0xA0000000
+
+# UART0 console: GUI window plus a TCP socket reachable from the host (port published by
+# podman-compose). From the host run:  telnet localhost 3456   (or: nc localhost 3456)
+showAnalyzer uart0
+emulation CreateServerSocketTerminal 3456 "uart0term"
+connector Connect uart0 uart0term
+
+echo "ElemRV-C co-sim ready. Type 'start' to run."

--- a/hardware/scala/elemrv_c/elemrv_c_emul.repl
+++ b/hardware/scala/elemrv_c/elemrv_c_emul.repl
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+// ElemRV-C (Hydrogen platform) - Renode functional model.
+// Mirrors hardware/scala/elemrv_c/ElemRV.scala + zibal Hydrogen.scala.
+
+// CPU: VexiiRiscv RV32IMC + Zicsr, modeled as a generic RISC-V 32-bit core.
+cpu: CPU.RiscV32 @ sysbus
+    cpuType: "rv32imc_zicsr"
+    timeProvider: empty
+    privilegeArchitecture: PrivilegeArchitecture.Priv1_10
+
+// On-chip RAM: 8 KB @ 0x80000000
+ram: Memory.MappedMemory @ sysbus 0x80000000
+    size: 0x00002000
+
+// SPI XIP flash @ 0xA0000000 (reset/boot region)
+flash: Memory.MappedMemory @ sysbus 0xA0000000
+    size: 0x02000000
+
+// Machine timer (mtime/mtimecmp) @ 0xF0020000 - drives the CPU MTIP line (cause 7).
+mtimer: Timers.MachineTimerCtrl @ sysbus 0xF0020000
+    frequency: 50000000
+    -> cpu@7
+
+// PLIC @ 0xF0800000 (Nafarr PLIC, standard SiFive map; gateway latch + write-to-complete,
+// read-claim optional). Output context 0 -> CPU external-interrupt line (cause 11).
+// Sources match soc.h IRQ numbers: gpio0=3, i2c0=4, pio0=5, pwm0=6, uart0=7, watchdog=1.
+plic: IRQControllers.PlicCtrl @ sysbus 0xF0800000
+    0 -> cpu@11
+    numberOfSources: 31
+
+// GPIO0: 12 pins @ 0xF0000000 (Nafarr GpioCtrl) - IRQ is PLIC source 3.
+gpio0: GPIOPort.GpioCtrl @ sysbus 0xF0000000
+    numberOfPins: 12
+    IRQ -> plic@3
+
+// LED on GPIO0 pin 1 - lit when the pin is driven high.
+led1: Miscellaneous.LED @ gpio0 1
+
+// UART0 @ 0xF0004000 (Nafarr UartCtrl) - console output / RX injection; IRQ is PLIC source 7.
+uart0: UART.UartCtrl @ sysbus 0xF0004000
+    IRQ -> plic@7
+
+// PRNG @ 0xF0005000 (Nafarr PrngCtrl) - xorshift output (not the RTL LFSR sequence).
+prng: Miscellaneous.PrngCtrl @ sysbus 0xF0005000
+
+// Syscon @ 0xF0023000 (Nafarr Syscon) - read-only platform identity + 50 MHz reference clock.
+syscon: Miscellaneous.Syscon @ sysbus 0xF0023000
+    refClockHz: 50000000
+
+// Clock controller @ 0xF0022000 (Nafarr ClockControllerCtrl) - per-domain enable; ratios placeholder.
+clockCtrl: Miscellaneous.ClockControllerCtrl @ sysbus 0xF0022000
+    numberOfDomains: 2
+
+// SPI XIP config bus @ 0xF0025000 (Nafarr SpiXipControllerCtrl) - flash XIP cfg only.
+// (0xF0024000 is the separate SPI controller command interface - not modeled.)
+spiXipCfg: Miscellaneous.SpiXipControllerCtrl @ sysbus 0xF0025000
+
+// Pinmux @ 0xF0010000 (Nafarr PinmuxCtrl) - stores per-pin mux selection.
+pinmux: Miscellaneous.PinmuxCtrl @ sysbus 0xF0010000
+    width: 12
+    options: 2

--- a/hardware/scala/elemrv_c/elemrv_c_emul.resc
+++ b/hardware/scala/elemrv_c/elemrv_c_emul.resc
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2026 aesc silicon
+#
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+
+:name: ElemRV-C
+:description: Functional emulation of ElemRV-C booting a bare-metal binary from XIP flash.
+
+# Path to the application binary (boots from XIP flash @ 0xA0000000).
+# Override on the command line, e.g.:  renode -e "set bin @build/app.bin; include @elemrv_c_emul.resc"
+$bin ?= @build/app.bin
+
+# Compile and register the custom Nafarr peripheral models (live next to their .scala).
+i @modules/elements/nafarr/hardware/scala/nafarr/peripherals/io/gpio/GpioCtrl.cs
+i @modules/elements/nafarr/hardware/scala/nafarr/peripherals/com/uart/UartCtrl.cs
+i @modules/elements/nafarr/hardware/scala/nafarr/peripherals/pinmux/PinmuxCtrl.cs
+i @modules/elements/nafarr/hardware/scala/nafarr/crypto/prng/PrngCtrl.cs
+i @modules/elements/nafarr/hardware/scala/nafarr/system/mtimer/MachineTimerCtrl.cs
+i @modules/elements/nafarr/hardware/scala/nafarr/system/plic/PlicCtrl.cs
+i @modules/elements/nafarr/hardware/scala/nafarr/system/syscon/Syscon.cs
+i @modules/elements/nafarr/hardware/scala/nafarr/system/clock/ClockControllerCtrl.cs
+i @modules/elements/nafarr/hardware/scala/nafarr/memory/spi/SpiXipControllerCtrl.cs
+
+mach create "elemrv_c"
+machine LoadPlatformDescription @hardware/scala/elemrv_c/elemrv_c_emul.repl
+
+# Load the application into XIP flash and point the reset vector at it.
+sysbus LoadBinary $bin 0xA0000000
+cpu PC 0xA0000000
+
+# Interactive UART0 console.
+#
+# GUI terminal window (requires the Renode GUI, i.e. an X display; ignored when headless):
+showAnalyzer uart0
+#
+# TCP socket backend, reachable from the HOST (a PTY device would only exist inside the
+# container). Port 3456 is published by podman-compose; from the host run:
+#   telnet localhost 3456      (or: nc localhost 3456)
+emulation CreateServerSocketTerminal 3456 "uart0term"
+connector Connect uart0 uart0term
+
+# GPIO0 pin 1 has an LED (led1) for the full Renode GUI: `showAnalyzer gpio0.led1`.
+# In --console / headless mode there's no LED widget, so GpioCtrl logs output-pin changes
+# instead (visible in the monitor). Raise GPIO verbosity if needed:  logLevel 0 gpio0
+
+# To trace GPIO register access, raise its verbosity:  logLevel 0 gpio0
+
+echo "ElemRV-C ready."

--- a/hardware/scala/elemrv_h/elemrv_h_cosim.repl
+++ b/hardware/scala/elemrv_h/elemrv_h_cosim.repl
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+// ElemRV-H co-simulation platform.
+// All I/O + system peripherals are the *real* Verilated TileLink RTL; CPU, interconnect, OCRAM,
+// flash, plus uart0 (console), plic and mtimer (interrupt timing) stay functional for speed.
+// Each co-simulated peripheral is its own Verilated library (build/<SOC>/<board>/cosim/<name>/libVtop.so);
+// the .resc binds the SimulationFilePath for each. cosim->Renode signal 0 = io_interrupt, 1 = io_error.
+
+// CPU: VexiiRiscv RV32I + Zicsr, modeled as a generic RISC-V 32-bit core.
+cpu: CPU.RiscV32 @ sysbus
+    cpuType: "rv32i_zicsr"
+    timeProvider: empty
+    privilegeArchitecture: PrivilegeArchitecture.Priv1_10
+
+// On-chip RAM: 8 KB @ 0x80000000
+ram: Memory.MappedMemory @ sysbus 0x80000000
+    size: 0x00002000
+
+// SPI XIP flash @ 0xA0000000 (reset/boot region)
+flash: Memory.MappedMemory @ sysbus 0xA0000000
+    size: 0x02000000
+
+// Machine timer (mtime/mtimecmp) @ 0xF0020000 - drives the CPU MTIP line (cause 7). FUNCTIONAL.
+mtimer: Timers.MachineTimerCtrl @ sysbus 0xF0020000
+    frequency: 50000000
+    -> cpu@7
+
+// PLIC @ 0xF0800000 - output context 0 -> CPU external-interrupt line (cause 11). FUNCTIONAL.
+// Sources match soc.h IRQ numbers: gpio0=3, i2c0=4, pio0=5, pwm0=6, uart0=7, watchdog=1.
+plic: IRQControllers.PlicCtrl @ sysbus 0xF0800000
+    0 -> cpu@11
+    numberOfSources: 31
+
+// UART0 @ 0xF0004000 - kept FUNCTIONAL so the Renode console/PTY works; IRQ is PLIC source 7.
+uart0: UART.UartCtrl @ sysbus 0xF0004000
+    IRQ -> plic@7
+
+// SPI XIP config bus @ 0xF0025000 - kept FUNCTIONAL (multi-bus controller, not a single TL slave).
+spiXipCfg: Miscellaneous.SpiXipControllerCtrl @ sysbus 0xF0025000
+
+// ---------------------------------------------------------------------------
+// Co-simulated peripherals (real Verilated RTL). signal 0 = io_interrupt, 1 = io_error.
+// ---------------------------------------------------------------------------
+
+// GPIO0 @ 0xF0000000 (TileLinkGpio) - IRQ -> PLIC source 3.
+gpio0: CoSimulated.CoSimulatedPeripheral @ sysbus <0xF0000000, +0x1000>
+    frequency: 50000000
+    limitBuffer: 1000000
+    timeout: 10000
+    0 -> plic@3
+    cosimToRenodeSignalRange: <0, +1>
+
+// I2C0 @ 0xF0001000 (TileLinkI2cController) - IRQ -> PLIC source 4.
+i2c0: CoSimulated.CoSimulatedPeripheral @ sysbus <0xF0001000, +0x1000>
+    frequency: 50000000
+    limitBuffer: 1000000
+    timeout: 10000
+    0 -> plic@4
+    cosimToRenodeSignalRange: <0, +1>
+
+// PIO0 @ 0xF0002000 (TileLinkPio) - IRQ -> PLIC source 5; signal 1 = error (unrouted).
+pio0: CoSimulated.CoSimulatedPeripheral @ sysbus <0xF0002000, +0x1000>
+    frequency: 50000000
+    limitBuffer: 1000000
+    timeout: 10000
+    0 -> plic@5
+    cosimToRenodeSignalRange: <0, +2>
+
+// PWM0 @ 0xF0003000 (TileLinkPwm) - IRQ -> PLIC source 6; signal 1 = error (unrouted).
+pwm0: CoSimulated.CoSimulatedPeripheral @ sysbus <0xF0003000, +0x1000>
+    frequency: 50000000
+    limitBuffer: 1000000
+    timeout: 10000
+    0 -> plic@6
+    cosimToRenodeSignalRange: <0, +2>
+
+// PRNG @ 0xF0005000 (TileLinkPrng) - signal 0 = error (unrouted, no PLIC IRQ).
+prng: CoSimulated.CoSimulatedPeripheral @ sysbus <0xF0005000, +0x1000>
+    frequency: 50000000
+    limitBuffer: 1000000
+    timeout: 10000
+    cosimToRenodeSignalRange: <0, +1>
+
+// Pinmux @ 0xF0010000 (TileLinkPinmux) - no interrupt/error.
+pinmux: CoSimulated.CoSimulatedPeripheral @ sysbus <0xF0010000, +0x1000>
+    frequency: 50000000
+    limitBuffer: 1000000
+    timeout: 10000
+
+// Reset controller @ 0xF0021000 (TileLinkResetController) - no interrupt/error.
+resetCtrl: CoSimulated.CoSimulatedPeripheral @ sysbus <0xF0021000, +0x1000>
+    frequency: 50000000
+    limitBuffer: 1000000
+    timeout: 10000
+
+// Clock controller @ 0xF0022000 (TileLinkClockController) - no interrupt/error.
+clockCtrl: CoSimulated.CoSimulatedPeripheral @ sysbus <0xF0022000, +0x1000>
+    frequency: 50000000
+    limitBuffer: 1000000
+    timeout: 10000
+
+// Syscon @ 0xF0023000 (TileLinkSyscon) - no interrupt/error.
+syscon: CoSimulated.CoSimulatedPeripheral @ sysbus <0xF0023000, +0x1000>
+    frequency: 50000000
+    limitBuffer: 1000000
+    timeout: 10000
+
+// Watchdog @ 0xF0027000 (TileLinkWatchdog) - IRQ -> PLIC source 1; signal 1 = error (unrouted).
+watchdog: CoSimulated.CoSimulatedPeripheral @ sysbus <0xF0027000, +0x1000>
+    frequency: 50000000
+    limitBuffer: 1000000
+    timeout: 10000
+    0 -> plic@1
+    cosimToRenodeSignalRange: <0, +2>
+
+// ESM @ 0xF0028000 (TileLinkEsm) - register RTL only; its non-standard signal outputs
+// (io_infoInterrupt/io_warnInterrupt/io_errorSignal) are not surfaced.
+esm: CoSimulated.CoSimulatedPeripheral @ sysbus <0xF0028000, +0x1000>
+    frequency: 50000000
+    limitBuffer: 1000000
+    timeout: 10000

--- a/hardware/scala/elemrv_h/elemrv_h_cosim.resc
+++ b/hardware/scala/elemrv_h/elemrv_h_cosim.resc
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2026 aesc silicon
+#
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+
+:name: ElemRV-H (co-simulation)
+:description: Boots a binary with all peripherals as Verilated TileLink RTL; CPU/UART/PLIC/mtimer functional.
+
+# Application binary and the directory holding the per-peripheral co-sim libraries
+# (built by 'task cosim-build' -> <cosimdir>/<name>/libVtop.so).
+$bin ?= @build/app.bin
+$cosimdir ?= @build/ElemRV-H/SG13CMOS5L/cosim
+
+# Functional peripheral models that stay in Renode (the rest are co-simulated RTL).
+i @modules/elements/nafarr/hardware/scala/nafarr/peripherals/com/uart/UartCtrl.cs
+i @modules/elements/nafarr/hardware/scala/nafarr/system/mtimer/MachineTimerCtrl.cs
+i @modules/elements/nafarr/hardware/scala/nafarr/system/plic/PlicCtrl.cs
+i @modules/elements/nafarr/hardware/scala/nafarr/memory/spi/SpiXipControllerCtrl.cs
+
+mach create "elemrv_h_cosim"
+machine LoadPlatformDescription @hardware/scala/elemrv_h/elemrv_h_cosim.repl
+
+# Bind each co-simulated peripheral to its Verilated library.
+gpio0     SimulationFilePathLinux $cosimdir/gpio0/libVtop.so
+i2c0      SimulationFilePathLinux $cosimdir/i2c0/libVtop.so
+pio0      SimulationFilePathLinux $cosimdir/pio0/libVtop.so
+pwm0      SimulationFilePathLinux $cosimdir/pwm0/libVtop.so
+prng      SimulationFilePathLinux $cosimdir/prng/libVtop.so
+pinmux    SimulationFilePathLinux $cosimdir/pinmux/libVtop.so
+resetCtrl SimulationFilePathLinux $cosimdir/resetCtrl/libVtop.so
+clockCtrl SimulationFilePathLinux $cosimdir/clockCtrl/libVtop.so
+syscon    SimulationFilePathLinux $cosimdir/syscon/libVtop.so
+watchdog  SimulationFilePathLinux $cosimdir/watchdog/libVtop.so
+esm       SimulationFilePathLinux $cosimdir/esm/libVtop.so
+
+# Boot from XIP flash (same flow as elemrv_h_emul.resc).
+sysbus LoadBinary $bin 0xA0000000
+cpu PC 0xA0000000
+
+# UART0 console: GUI window plus a TCP socket reachable from the host (port published by
+# podman-compose). From the host run:  telnet localhost 3456   (or: nc localhost 3456)
+showAnalyzer uart0
+emulation CreateServerSocketTerminal 3456 "uart0term"
+connector Connect uart0 uart0term
+
+echo "ElemRV-H co-sim ready. Type 'start' to run."

--- a/hardware/scala/elemrv_h/elemrv_h_emul.repl
+++ b/hardware/scala/elemrv_h/elemrv_h_emul.repl
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+// ElemRV-H (Hydrogen platform) - Renode functional model.
+// Mirrors hardware/scala/elemrv_h/ElemRV.scala + zibal Hydrogen.scala.
+
+// CPU: VexiiRiscv RV32I + Zicsr, modeled as a generic RISC-V 32-bit core.
+cpu: CPU.RiscV32 @ sysbus
+    cpuType: "rv32i_zicsr"
+    timeProvider: empty
+    privilegeArchitecture: PrivilegeArchitecture.Priv1_10
+
+// On-chip RAM: 8 KB @ 0x80000000
+ram: Memory.MappedMemory @ sysbus 0x80000000
+    size: 0x00002000
+
+// SPI XIP flash @ 0xA0000000 (reset/boot region)
+flash: Memory.MappedMemory @ sysbus 0xA0000000
+    size: 0x02000000
+
+// Machine timer (mtime/mtimecmp) @ 0xF0020000 - drives the CPU MTIP line (cause 7).
+mtimer: Timers.MachineTimerCtrl @ sysbus 0xF0020000
+    frequency: 50000000
+    -> cpu@7
+
+// PLIC @ 0xF0800000 (Nafarr PLIC, standard SiFive map; gateway latch + write-to-complete,
+// read-claim optional). Output context 0 -> CPU external-interrupt line (cause 11).
+// Sources match soc.h IRQ numbers: gpio0=3, i2c0=4, pio0=5, pwm0=6, uart0=7, watchdog=1.
+plic: IRQControllers.PlicCtrl @ sysbus 0xF0800000
+    0 -> cpu@11
+    numberOfSources: 31
+
+// GPIO0: 12 pins @ 0xF0000000 (Nafarr GpioCtrl) - IRQ is PLIC source 3.
+gpio0: GPIOPort.GpioCtrl @ sysbus 0xF0000000
+    numberOfPins: 12
+    IRQ -> plic@3
+
+// LED on GPIO0 pin 1 - lit when the pin is driven high.
+led1: Miscellaneous.LED @ gpio0 1
+
+// UART0 @ 0xF0004000 (Nafarr UartCtrl) - console output / RX injection; IRQ is PLIC source 7.
+uart0: UART.UartCtrl @ sysbus 0xF0004000
+    IRQ -> plic@7
+
+// PRNG @ 0xF0005000 (Nafarr PrngCtrl) - xorshift output (not the RTL LFSR sequence).
+prng: Miscellaneous.PrngCtrl @ sysbus 0xF0005000
+
+// Syscon @ 0xF0023000 (Nafarr Syscon) - read-only platform identity + 50 MHz reference clock.
+syscon: Miscellaneous.Syscon @ sysbus 0xF0023000
+    refClockHz: 50000000
+
+// Clock controller @ 0xF0022000 (Nafarr ClockControllerCtrl) - per-domain enable; ratios placeholder.
+clockCtrl: Miscellaneous.ClockControllerCtrl @ sysbus 0xF0022000
+    numberOfDomains: 2
+
+// SPI XIP config bus @ 0xF0025000 (Nafarr SpiXipControllerCtrl) - flash XIP cfg only.
+// (0xF0024000 is the separate SPI controller command interface - not modeled.)
+spiXipCfg: Miscellaneous.SpiXipControllerCtrl @ sysbus 0xF0025000
+
+// Pinmux @ 0xF0010000 (Nafarr PinmuxCtrl) - stores per-pin mux selection.
+pinmux: Miscellaneous.PinmuxCtrl @ sysbus 0xF0010000
+    width: 12
+    options: 2

--- a/hardware/scala/elemrv_h/elemrv_h_emul.resc
+++ b/hardware/scala/elemrv_h/elemrv_h_emul.resc
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2026 aesc silicon
+#
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+
+:name: ElemRV-H
+:description: Functional emulation of ElemRV-H booting a bare-metal binary from XIP flash.
+
+# Path to the application binary (boots from XIP flash @ 0xA0000000).
+# Override on the command line, e.g.:  renode -e "set bin @build/app.bin; include @elemrv_h_emul.resc"
+$bin ?= @build/app.bin
+
+# Compile and register the custom Nafarr peripheral models (live next to their .scala).
+i @modules/elements/nafarr/hardware/scala/nafarr/peripherals/io/gpio/GpioCtrl.cs
+i @modules/elements/nafarr/hardware/scala/nafarr/peripherals/com/uart/UartCtrl.cs
+i @modules/elements/nafarr/hardware/scala/nafarr/peripherals/pinmux/PinmuxCtrl.cs
+i @modules/elements/nafarr/hardware/scala/nafarr/crypto/prng/PrngCtrl.cs
+i @modules/elements/nafarr/hardware/scala/nafarr/system/mtimer/MachineTimerCtrl.cs
+i @modules/elements/nafarr/hardware/scala/nafarr/system/plic/PlicCtrl.cs
+i @modules/elements/nafarr/hardware/scala/nafarr/system/syscon/Syscon.cs
+i @modules/elements/nafarr/hardware/scala/nafarr/system/clock/ClockControllerCtrl.cs
+i @modules/elements/nafarr/hardware/scala/nafarr/memory/spi/SpiXipControllerCtrl.cs
+
+mach create "elemrv_h"
+machine LoadPlatformDescription @hardware/scala/elemrv_h/elemrv_h_emul.repl
+
+# Load the application into XIP flash and point the reset vector at it.
+sysbus LoadBinary $bin 0xA0000000
+cpu PC 0xA0000000
+
+# Interactive UART0 console.
+#
+# GUI terminal window (requires the Renode GUI, i.e. an X display; ignored when headless):
+showAnalyzer uart0
+#
+# TCP socket backend, reachable from the HOST (a PTY device would only exist inside the
+# container). Port 3456 is published by podman-compose; from the host run:
+#   telnet localhost 3456      (or: nc localhost 3456)
+emulation CreateServerSocketTerminal 3456 "uart0term"
+connector Connect uart0 uart0term
+
+# GPIO0 pin 1 has an LED (led1) for the full Renode GUI: `showAnalyzer gpio0.led1`.
+# In --console / headless mode there's no LED widget, so GpioCtrl logs output-pin changes
+# instead (visible in the monitor). Raise GPIO verbosity if needed:  logLevel 0 gpio0
+
+# To trace GPIO register access, raise its verbosity:  logLevel 0 gpio0
+
+echo "ElemRV-H ready."

--- a/manifest-nightly.xml
+++ b/manifest-nightly.xml
@@ -17,5 +17,6 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 	<project name="SpinalHDL/VexiiRiscv" path="modules/elements/vexiiriscv" revision="" />
 	<project name="aesc-silicon/elements-vexriscv" path="modules/elements/vexriscv" revision="6814d54a341562beb330d407bb9898024367e447" />
 	<project name="aesc-silicon/OpenROAD-flow-scripts" path="tools/OpenROAD-flow-scripts" revision="ede8b54b2a6015bf2929832bee21015a833ec5f7" />
+	<project name="antmicro/renode-verilator-integration" path="tools/renode-verilator-integration" revision="master" />
 	<project name="aesc-silicon/IHP-Open-PDK" sync-s="true" path="pdks/IHP-Open-PDK" revision="64239e24bdbe742355c141e443b4149a2af0eaf3" />
 </manifest>

--- a/manifest.xml
+++ b/manifest.xml
@@ -11,8 +11,8 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 
 	<default remote="github" sync-j="8" />
 
-	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="5bc81ab38a68ddf0c9cf806596cdba7694f80d62" />
-	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="334661d9571129e822c586232479af1b8b4eaae2" />
+	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="289b90c39f13e87739b581d9c9995a59af5d212b" />
+	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="1e86e41e46d16ce4e2f38b73f17117f0ea9f251a" />
 	<project name="SpinalHDL/SpinalCrypto" path="modules/elements/SpinalCrypto" revision="f2a4ae9db5e9434c5589d0651efec8719103498e" />
 	<project name="SpinalHDL/VexiiRiscv" path="modules/elements/vexiiriscv" revision="03587f948b91f84197ecdbd958ba490977fd5671" />
 	<project name="aesc-silicon/elements-vexriscv" path="modules/elements/vexriscv" revision="6814d54a341562beb330d407bb9898024367e447" />

--- a/manifest.xml
+++ b/manifest.xml
@@ -17,5 +17,6 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 	<project name="SpinalHDL/VexiiRiscv" path="modules/elements/vexiiriscv" revision="03587f948b91f84197ecdbd958ba490977fd5671" />
 	<project name="aesc-silicon/elements-vexriscv" path="modules/elements/vexriscv" revision="6814d54a341562beb330d407bb9898024367e447" />
 	<project name="aesc-silicon/OpenROAD-flow-scripts" path="tools/OpenROAD-flow-scripts" revision="ede8b54b2a6015bf2929832bee21015a833ec5f7" />
+	<project name="antmicro/renode-verilator-integration" path="tools/renode-verilator-integration" revision="c9692ca32c8c160e0c268bd0f5207359cee1626d" />
 	<project name="aesc-silicon/IHP-Open-PDK" sync-s="true" path="pdks/IHP-Open-PDK" revision="5a64253fe0c1d816b8d06857d2f31e35303a5bae" />
 </manifest>

--- a/podman-compose-headless.yml
+++ b/podman-compose-headless.yml
@@ -14,6 +14,9 @@ services:
     container_name: elemrv_container
     environment:
       - DISPLAY=${DISPLAY}
+    ports:
+      # Renode UART0 socket terminal (virtual prototyping), reachable from the host.
+      - "3456:3456"
     volumes:
       - /home:/home
       - ivy2-cache:/root/.ivy2

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -14,6 +14,9 @@ services:
     container_name: elemrv_container
     environment:
       - DISPLAY=${DISPLAY}
+    ports:
+      # Renode UART0 socket terminal (virtual prototyping), reachable from the host.
+      - "3456:3456"
     volumes:
       - /home:/home
       - ivy2-cache:/root/.ivy2


### PR DESCRIPTION
Introduces virtual prototyping so software can be developed and drivers validated without physical hardware, alongside the existing full-RTL simulation.

**Emulation** (task emulate / emulate-gui) — fast, functional Renode models, no RTL:
  - Register-accurate C# peripheral models in Nafarr next to their .scala (GpioCtrl, UartCtrl, MachineTimerCtrl, PlicCtrl, Syscon, PrngCtrl, PinmuxCtrl, ClockControllerCtrl, SpiXipControllerCtrl).
  - UART console via GUI analyzer and a host-reachable TCP socket (port published by podman-compose).
  
**Co-simulation** (task cosim / cosim-build / cosim-gui) — Renode functional CPU/bus + real Verilated peripheral RTL:
  - Generic TileLink-UL bus driver and per-peripheral build harness in Zibal (hardware/renode/cosim/); one Verilated library per TileLink* module from the generated netlist (no Verilog generated/committed).
  - All I/O + system peripherals run as RTL; uart0, PLIC and mtimer stay functional.
  - renode-verilator-integration added to the manifests.
 
**Platforms**: *_emul/*_cosim .repl/.resc for ElemRV-H (rv32i_zicsr) and ElemRV-C (rv32imc_zicsr).

**Docs**: new Virtual Prototyping section (RTL Simulation / Emulation / Co-simulation); documentation cleaned to ASCII (keeping ✓).