### PR TITLE
build: Select the ASIC target via TARGET instead of PDK/board

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,9 @@ script:
   - CI=true IS_HEADLESS=true task install-zephyr
 
   # Prepare files
-  - CI=true IS_HEADLESS=true task SOC=ElemRV-H PDK=ihp-sg13cmos5l prepare
-  - CI=true IS_HEADLESS=true task SOC=ElemRV-C PDK=ihp-sg13cmos5l prepare
-  - CI=true IS_HEADLESS=true task SOC=ElemRV-N PDK=ihp-sg13g2 prepare
+  - CI=true IS_HEADLESS=true task SOC=ElemRV-H TARGET=SG13CMOS5L prepare
+  - CI=true IS_HEADLESS=true task SOC=ElemRV-C TARGET=SG13CMOS5L prepare
+  - CI=true IS_HEADLESS=true task SOC=ElemRV-N TARGET=SG13G2 prepare
 
   # Compile baremetal firmware
   - CI=true IS_HEADLESS=true task SOC=ElemRV-H baremetal:compile
@@ -61,30 +61,30 @@ script:
   - CI=true IS_HEADLESS=true task SOC=ElemRV-N baremetal:compile
 
   # Prepare FPGA files
-  - CI=true IS_HEADLESS=true task SOC=ElemRV-H fpga:prepare
-  - CI=true IS_HEADLESS=true task SOC=ElemRV-C fpga:prepare
-  - CI=true IS_HEADLESS=true task SOC=ElemRV-N fpga:prepare
+  - CI=true IS_HEADLESS=true task SOC=ElemRV-H TARGET=SG13CMOS5L fpga:prepare
+  - CI=true IS_HEADLESS=true task SOC=ElemRV-C TARGET=SG13CMOS5L fpga:prepare
+  - CI=true IS_HEADLESS=true task SOC=ElemRV-N TARGET=SG13G2 fpga:prepare
 
-  # TODO ElemRV-C are currently missing in Zephyr
+  # TODO ElemRV-C is currently missing in Zephyr
   # Compile Zephyr firmware
   - CI=true IS_HEADLESS=true task SOC=ElemRV-H zephyr:compile
   #- CI=true IS_HEADLESS=true task SOC=ElemRV-C zephyr:compile
   - CI=true IS_HEADLESS=true task SOC=ElemRV-N zephyr:compile
 
   # Synthesize FPGA design
-  - CI=true IS_HEADLESS=true task SOC=ElemRV-H fpga:synthesize
-  - CI=true IS_HEADLESS=true task SOC=ElemRV-C fpga:synthesize
-  - CI=true IS_HEADLESS=true task SOC=ElemRV-N fpga:synthesize
+  - CI=true IS_HEADLESS=true task SOC=ElemRV-H TARGET=SG13CMOS5L fpga:synthesize
+  - CI=true IS_HEADLESS=true task SOC=ElemRV-C TARGET=SG13CMOS5L fpga:synthesize
+  - CI=true IS_HEADLESS=true task SOC=ElemRV-N TARGET=SG13G2 fpga:synthesize
 
   # TODO Full RTL to GDS flow takes too long for travis
   # Generate layout
-  #- CI=true IS_HEADLESS=true task SOC=ElemRV-H PDK=ihp-sg13cmos5l layout
+  #- CI=true IS_HEADLESS=true task SOC=ElemRV-H TARGET=SG13CMOS5L layout
 
   # Add metal fill
-  #- CI=true IS_HEADLESS=true task SOC=ElemRV-H PDK=ihp-sg13cmos5l filler
+  #- CI=true IS_HEADLESS=true task SOC=ElemRV-H TARGET=SG13CMOS5L filler
 
   # Run maximal DRC
-  #- CI=true IS_HEADLESS=true task SOC=ElemRV-H PDK=ihp-sg13cmos5l run-drc
+  #- CI=true IS_HEADLESS=true task SOC=ElemRV-H TARGET=SG13CMOS5L run-drc
 
 notifications:
   email:

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ This project uses Taskfile as its task runner tool. You can install Taskfile usi
 
 Most tasks accept the ``SOC`` and ``PDK`` variables to select a specific SoC variant and target PDK. For example::
 
-        task prepare SOC=ElemRV-H PDK=ihp-sg13cmos5l
+        task prepare SOC=ElemRV-H TARGET=SG13CMOS5L
 
 **Note:** By default, the X-Server is required for the `view-klayout` and `view-openroad` tasks. On headless systems, you can bypass this requirement by adding `IS_HEADLESS=true` before the task command. This is particularly useful when accessing the system via SSH, as it allows you to run the container without the need for X-Server.
 

--- a/Taskfile.fpga.yml
+++ b/Taskfile.fpga.yml
@@ -21,14 +21,14 @@ tasks:
           project: "modules/elements/vexiiriscv"
       - task: ':lib-generate'
         vars:
-          board: "ECPIX5"
+          FPGA: "ECPIX5"
 
   synthesize:
     desc: Generates the FPGA bitstream by synthesizing the design.
     cmds:
       - task: ':lib-synthesize-fpga'
         vars:
-          board: "ECPIX5"
+          FPGA: "ECPIX5"
           vendor: "Lattice"
 
   flash:
@@ -36,18 +36,18 @@ tasks:
     cmds:
       - task: ':lib-flash-bitstream'
         vars:
-          board: "ECPIX5"
+          FPGA: "ECPIX5"
 
   simulate:
     desc: Runs simulations at the RTL level. Add 'duration=n' to specify the duration in n milliseconds.
     cmds:
       - task: ':lib-simulate'
         vars:
-          board: "ECPIX5"
+          FPGA: "ECPIX5"
 
   view-simulation:
     desc: Opens the simulation with GTKWave.
     cmds:
       - task: ':lib-view-simulation'
         vars:
-          board: "ECPIX5"
+          FPGA: "ECPIX5"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -19,7 +19,17 @@ includes:
 
 vars:
   SOC: '{{.SOC | default "ElemRV-N"}}'
-  PDK: '{{.PDK | default "ihp-sg13g2"}}'
+  # ASIC target = process node + on-chip config (SG13CMOS5L, GF180MCU, ...). Selects the PDK.
+  TARGET: '{{.TARGET | default "SG13G2"}}'
+  PDK:
+    sh: |
+      case "{{.TARGET}}" in
+        SG13G2)     echo "ihp-sg13g2" ;;
+        SG13CMOS5L) echo "ihp-sg13cmos5l" ;;
+        GF180MCU)   echo "gf180mcuD" ;;
+        SKY130)     echo "sky130A" ;;
+        *) echo ""; echo "Unknown TARGET: {{.TARGET}}" >&2; exit 1 ;;
+      esac
   TECH:
     sh: |
       case "{{.PDK}}" in
@@ -59,8 +69,6 @@ vars:
 
   package:
     sh: echo "{{.SOC}}" | tr '[:upper:]' '[:lower:]' | tr '-' '_'
-  board:
-    sh: echo "{{.TECH}}" | tr '[:lower:]' '[:upper:]'
 
   KLAYOUT_HOME: "{{.PWD}}/pdks/IHP-Open-PDK/{{.PDK}}/libs.tech/klayout/"
   CONTAINER_NAME: elemrv_container
@@ -70,7 +78,8 @@ vars:
     -e PDK_FAMILY={{.PDK_FAMILY}} \
     -e PDK_ROOT={{.PDK_ROOT}} \
     -e SOC={{.SOC}} \
-    -e BOARD={{.board}} \
+    -e TARGET={{.TARGET}} \
+    -e BOARD={{.TARGET}} \
     -e FPGA_FAMILY={{.FPGA_FAMILY}} \
     -e FPGA_DEVICE={{.FPGA_DEVICE}} \
     -e FPGA_PACKAGE={{.FPGA_PACKAGE}} \
@@ -83,7 +92,7 @@ vars:
     -e USER={{.USER}} \
     -e ZEPHYR_SDK_INSTALL_DIR={{.ZEPHYR_SDK_INSTALL_DIR}} \
     -e GCC={{.GCC}} \
-    -e RULES_JSON={{.PWD}}/hardware/scala/{{.package}}/{{.board}}/rules.json \
+    -e RULES_JSON={{.PWD}}/hardware/scala/{{.package}}/{{.TARGET}}/rules.json \
 "
 
 env:
@@ -159,9 +168,9 @@ tasks:
           project: "modules/elements/vexiiriscv"
       - task: lib-generate
       - task: lib-sealring
-      - "mkdir -p {{.BUILD_ROOT}}/{{.SOC}}/{{.board}}/zibal/macros/bondpad"
-      - "cp tmp/{{.PDK}}/bondpad_70x70.lef {{.BUILD_ROOT}}/{{.SOC}}/{{.board}}/zibal/macros/bondpad/"
-      - "cp tmp/{{.PDK}}/bondpad_70x70.gds.gz {{.BUILD_ROOT}}/{{.SOC}}/{{.board}}/zibal/macros/bondpad/bondpad_70x70.gds.gz"
+      - "mkdir -p {{.BUILD_ROOT}}/{{.SOC}}/{{.TARGET}}/zibal/macros/bondpad"
+      - "cp tmp/{{.PDK}}/bondpad_70x70.lef {{.BUILD_ROOT}}/{{.SOC}}/{{.TARGET}}/zibal/macros/bondpad/"
+      - "cp tmp/{{.PDK}}/bondpad_70x70.gds.gz {{.BUILD_ROOT}}/{{.SOC}}/{{.TARGET}}/zibal/macros/bondpad/bondpad_70x70.gds.gz"
       # TODO: wait until bondpad.py got fixed
       #- task: lib-bondpad
 

--- a/docs/source/flows/chip.rst
+++ b/docs/source/flows/chip.rst
@@ -12,7 +12,7 @@ Two Taskfile variables control which platform is built:
 
 To build a different platform, prepend the variables to any task::
 
-    task SOC=ElemRV-H board=SG13G2 prepare
+    task SOC=ElemRV-H TARGET=SG13G2 prepare
 
 Full Flow
 *********

--- a/docs/source/flows/firmware.rst
+++ b/docs/source/flows/firmware.rst
@@ -30,7 +30,7 @@ Compile
 
 To target a specific platform::
 
-    task baremetal:compile SOC=ElemRV-N board=SG13G2
+    task baremetal:compile SOC=ElemRV-N TARGET=SG13G2
 
 The compiled image is written to::
 
@@ -51,7 +51,7 @@ Compile
 
 To target a specific platform::
 
-    task zephyr:compile SOC=ElemRV-N board=SG13G2
+    task zephyr:compile SOC=ElemRV-N TARGET=SG13G2
 
 The compiled image is written to::
 

--- a/docs/source/flows/fpga.rst
+++ b/docs/source/flows/fpga.rst
@@ -14,7 +14,7 @@ Full Flow
 
 To run prepare, synthesize, and flash in one step::
 
-    task fpga
+    task fpga SOC=ElemRV-H TARGET=SG13CMOS5L
 
 Step by Step
 ************
@@ -23,33 +23,33 @@ Step by Step
 
 Generates the Verilog netlist and all metadata required for FPGA synthesis::
 
-    task fpga:prepare
+    task fpga:prepare SOC=ElemRV-H TARGET=SG13CMOS5L
 
 **2. Synthesize**
 
 Runs Yosys synthesis followed by nextpnr place-and-route to produce the
 bitstream::
 
-    task fpga:synthesize
+    task fpga:synthesize SOC=ElemRV-H TARGET=SG13CMOS5L
 
 **3. Flash**
 
 Programs the ECP5 with the generated bitstream over USB::
 
-    task fpga:flash
+    task fpga:flash SOC=ElemRV-H TARGET=SG13CMOS5L
 
 Simulation
 **********
 
 The design can be simulated at RTL level using Verilator before flashing::
 
-    task fpga:simulate
+    task fpga:simulate SOC=ElemRV-H TARGET=SG13CMOS5L
 
 By default the simulation runs until it finishes. To limit the run to a
 specific duration, pass ``duration`` in milliseconds::
 
-    task fpga:simulate duration=100
+    task fpga:simulate SOC=ElemRV-H TARGET=SG13CMOS5L duration=100
 
 To inspect the waveforms afterwards, open the simulation output in GTKWave::
 
-    task fpga:view-simulation
+    task fpga:view-simulation SOC=ElemRV-H TARGET=SG13CMOS5L

--- a/docs/source/virtual-prototyping/co-simulation.rst
+++ b/docs/source/virtual-prototyping/co-simulation.rst
@@ -23,7 +23,7 @@ Co-simulation requires the generated netlist (run the relevant flow's
 ``renode-verilator-integration`` checkout provided by the manifest. Verilate and
 compile one library per peripheral with::
 
-    task cosim-build SOC=ElemRV-H PDK=ihp-sg13cmos5l
+    task cosim-build SOC=ElemRV-H TARGET=SG13CMOS5L
 
 The libraries are produced under ``build/<SOC>/<board>/cosim/<peripheral>/``.
 
@@ -33,11 +33,11 @@ Running
 ``cosim`` rebuilds the libraries (incrementally - unchanged peripherals are a
 no-op) and boots the firmware::
 
-    task cosim SOC=ElemRV-H PDK=ihp-sg13cmos5l
+    task cosim SOC=ElemRV-H TARGET=SG13CMOS5L
 
 For the full Renode GUI::
 
-    task cosim-gui SOC=ElemRV-H PDK=ihp-sg13cmos5l
+    task cosim-gui SOC=ElemRV-H TARGET=SG13CMOS5L
 
 The UART console (GUI window and host TCP socket on port 3456) works exactly as
 in :doc:`emulation`.

--- a/docs/source/virtual-prototyping/emulation.rst
+++ b/docs/source/virtual-prototyping/emulation.rst
@@ -16,12 +16,12 @@ Running
 
 Boot the platform's firmware image headless (console in the terminal)::
 
-    task emulate SOC=ElemRV-H PDK=ihp-sg13cmos5l
+    task emulate SOC=ElemRV-H TARGET=SG13CMOS5L
 
 To launch the full Renode GUI (monitor window plus peripheral analyzers, e.g. an
 LED widget)::
 
-    task emulate-gui SOC=ElemRV-H PDK=ihp-sg13cmos5l
+    task emulate-gui SOC=ElemRV-H TARGET=SG13CMOS5L
 
 The firmware image is taken from ``build/<SOC>/firmware/`` - build it with the
 :doc:`../flows/firmware` flow first.

--- a/docs/source/virtual-prototyping/index.rst
+++ b/docs/source/virtual-prototyping/index.rst
@@ -36,7 +36,7 @@ All three are driven by `Taskfile <https://taskfile.dev>`_ inside the container
 and select the platform with ``SOC`` and ``PDK`` (see :doc:`../installation`),
 for example::
 
-    task emulate SOC=ElemRV-H PDK=ihp-sg13cmos5l
+    task emulate SOC=ElemRV-H TARGET=SG13CMOS5L
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/virtual-prototyping/rtl-simulation.rst
+++ b/docs/source/virtual-prototyping/rtl-simulation.rst
@@ -12,19 +12,19 @@ Running
 
 To simulate the configured platform::
 
-    task simulate SOC=ElemRV-H PDK=ihp-sg13cmos5l
+    task simulate SOC=ElemRV-H TARGET=SG13CMOS5L
 
 By default the simulation runs to completion. Limit it to a fixed duration in
 milliseconds with ``duration``::
 
-    task simulate SOC=ElemRV-H PDK=ihp-sg13cmos5l duration=100
+    task simulate SOC=ElemRV-H TARGET=SG13CMOS5L duration=100
 
 Waveforms
 *********
 
 Open the recorded waveforms in GTKWave after a run::
 
-    task view-simulation SOC=ElemRV-H PDK=ihp-sg13cmos5l
+    task view-simulation SOC=ElemRV-H TARGET=SG13CMOS5L
 
 When to use
 ***********

--- a/hardware/scala/elemrv_c/SG13CMOS5L/ECPIX5/ECPIX5.scala
+++ b/hardware/scala/elemrv_c/SG13CMOS5L/ECPIX5/ECPIX5.scala
@@ -1,8 +1,10 @@
-// SPDX-FileCopyrightText: 2025 aesc silicon
+// SPDX-FileCopyrightText: 2026 aesc silicon
 //
 // SPDX-License-Identifier: CERN-OHL-W-2.0
 
-package elemrv_h
+package elemrv_c.SG13CMOS5L
+
+import elemrv_c.ElemRV
 
 import spinal.core._
 import spinal.core.sim._
@@ -16,7 +18,7 @@ import nafarr.system.clock.ClockControllerCtrl._
 import nafarr.blackboxes.lattice.ecp5._
 
 import zibal.misc._
-import zibal.platform.Hydrogen
+import zibal.platform.Carbon
 import zibal.board.{KitParameter, BoardParameter}
 import zibal.sim.hyperram.W956A8MBYA
 import zibal.sim.MT25Q
@@ -96,10 +98,11 @@ case class ECPIX5Top() extends Component {
   val kitParameter = KitParameter(resets, clocks, inputClock)
   val boardParameter = ECPIX5.Parameter(kitParameter, ECPIX5.SystemClock.frequency)
   val socParameter = ElemRV.Parameter(boardParameter)
-  val parameter = Hydrogen.Parameter(
+  val parameter = Carbon.Parameter(
     socParameter,
     onChipRamSize = 8 kB,
     spiFlashSize = 512 kB,
+    iCacheSize = 4 kB,
     (parameter: ResetControllerCtrl.Parameter) => {
       val resetCtrl = new ResetControllerCtrl.GeneratorResetController(parameter)
       resetCtrl

--- a/hardware/scala/elemrv_h/SG13CMOS5L/ECPIX5/ECPIX5.scala
+++ b/hardware/scala/elemrv_h/SG13CMOS5L/ECPIX5/ECPIX5.scala
@@ -1,8 +1,10 @@
-// SPDX-FileCopyrightText: 2026 aesc silicon
+// SPDX-FileCopyrightText: 2025 aesc silicon
 //
 // SPDX-License-Identifier: CERN-OHL-W-2.0
 
-package elemrv_c
+package elemrv_h.SG13CMOS5L
+
+import elemrv_h.ElemRV
 
 import spinal.core._
 import spinal.core.sim._
@@ -16,7 +18,7 @@ import nafarr.system.clock.ClockControllerCtrl._
 import nafarr.blackboxes.lattice.ecp5._
 
 import zibal.misc._
-import zibal.platform.Carbon
+import zibal.platform.Hydrogen
 import zibal.board.{KitParameter, BoardParameter}
 import zibal.sim.hyperram.W956A8MBYA
 import zibal.sim.MT25Q
@@ -96,11 +98,10 @@ case class ECPIX5Top() extends Component {
   val kitParameter = KitParameter(resets, clocks, inputClock)
   val boardParameter = ECPIX5.Parameter(kitParameter, ECPIX5.SystemClock.frequency)
   val socParameter = ElemRV.Parameter(boardParameter)
-  val parameter = Carbon.Parameter(
+  val parameter = Hydrogen.Parameter(
     socParameter,
     onChipRamSize = 8 kB,
     spiFlashSize = 512 kB,
-    iCacheSize = 4 kB,
     (parameter: ResetControllerCtrl.Parameter) => {
       val resetCtrl = new ResetControllerCtrl.GeneratorResetController(parameter)
       resetCtrl

--- a/hardware/scala/elemrv_n/SG13G2/ECPIX5/ECPIX5.scala
+++ b/hardware/scala/elemrv_n/SG13G2/ECPIX5/ECPIX5.scala
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: CERN-OHL-W-2.0
 
-package elemrv_n
+package elemrv_n.SG13G2
+
+import elemrv_n.ElemRV
 
 import spinal.core._
 import spinal.core.sim._

--- a/manifest.xml
+++ b/manifest.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 	<default remote="github" sync-j="8" />
 
 	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="289b90c39f13e87739b581d9c9995a59af5d212b" />
-	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="1e86e41e46d16ce4e2f38b73f17117f0ea9f251a" />
+	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="639f2172f2f6a9fc41369fafcf0bac08eff2cfca" />
 	<project name="SpinalHDL/SpinalCrypto" path="modules/elements/SpinalCrypto" revision="f2a4ae9db5e9434c5589d0651efec8719103498e" />
 	<project name="SpinalHDL/VexiiRiscv" path="modules/elements/vexiiriscv" revision="03587f948b91f84197ecdbd958ba490977fd5671" />
 	<project name="aesc-silicon/elements-vexriscv" path="modules/elements/vexriscv" revision="6814d54a341562beb330d407bb9898024367e447" />


### PR DESCRIPTION
The build was selected with PDK= and an implicitly derived `board` (e.g. SG13CMOS5L), which conflated the process node with a "board". Rework the model around explicit dimensions:

- TARGET names the ASIC target (SG13CMOS5L, GF180MCU, SG13G2) and derives the PDK; the `board` variable is gone.
- FPGA verification is a separate dimension: the FPGA board (ECPIX5) is nested under the target it verifies, both in the source tree (hardware/scala/<soc>/<TARGET>/ECPIX5/) and the build output (build/<SOC>/<TARGET>/fpga/<BOARD>/).
- ECPIX5 tops are repackaged as <soc>.<TARGET>.ECPIX5* so multiple targets can each have their own FPGA board without colliding.

Usage:
    task layout  SOC=ElemRV-H TARGET=SG13CMOS5L
    task fpga    SOC=ElemRV-H TARGET=SG13CMOS5L

Update .travis.yml, README, and the flow/virtual-prototyping docs to the TARGET= form.