### PR TITLE
Taskfile: {baremetal,zephyr}: Add precondition

### DIFF
--- a/Taskfile.baremetal.yml
+++ b/Taskfile.baremetal.yml
@@ -18,6 +18,9 @@ vars:
 tasks:
   compile:
     desc: Compiles bare metal firmwares.
+    preconditions:
+      - sh: 'test -f {{.BUILD_ROOT}}/{{.SOC}}/firmware/storages.yaml'
+        msg: "Design not generated. Run 'task SOC={{.SOC}} asic:prepare' first."
     cmds:
       - task: ':lib-baremetal-firmware'
         vars:

--- a/Taskfile.zephyr.yml
+++ b/Taskfile.zephyr.yml
@@ -18,6 +18,9 @@ vars:
 tasks:
   compile:
     desc: Compiles the bootrom and Zephyr firmware and packages them into an image container.
+    preconditions:
+      - sh: 'test -f {{.BUILD_ROOT}}/{{.SOC}}/firmware/storages.yaml'
+        msg: "Design not generated. Run 'task SOC={{.SOC}} asic:prepare' first."
     cmds:
       - task: ':lib-baremetal-firmware'
         vars:


### PR DESCRIPTION
Check whether firmware related meta data already exist. If not, prompt how to generate them.

The bare-metal build needs a generated soc.h file with information about the underlying hardware.

-----

Fixes #38 