### PR TITLE
Fix Zibal Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,9 +72,9 @@ script:
   - CI=true IS_HEADLESS=true task SOC=ElemRV-N zephyr:compile
 
   # Synthesize FPGA design
-  - CI=true IS_HEADLESS=true task SOC=ElemRV-H TARGET=SG13CMOS5L fpga:synthesize
-  - CI=true IS_HEADLESS=true task SOC=ElemRV-C TARGET=SG13CMOS5L fpga:synthesize
-  - CI=true IS_HEADLESS=true task SOC=ElemRV-N TARGET=SG13CMOS5L fpga:synthesize
+  - CI=true IS_HEADLESS=true travis_wait 20 task SOC=ElemRV-H TARGET=SG13CMOS5L fpga:synthesize
+  - CI=true IS_HEADLESS=true travis_wait 20 task SOC=ElemRV-C TARGET=SG13CMOS5L fpga:synthesize
+  - CI=true IS_HEADLESS=true travis_wait 20 task SOC=ElemRV-N TARGET=SG13CMOS5L fpga:synthesize
 
   # TODO Full RTL to GDS flow takes too long for travis
   # Generate layout

--- a/Taskfile.asic.yml
+++ b/Taskfile.asic.yml
@@ -19,9 +19,6 @@ tasks:
   prepare:
     desc: Generates all necessary source files and metadata for chip layout creation.
     cmds:
-      - task: ':lib-sbt-publishLocal'
-        vars:
-          project: "modules/elements/vexiiriscv"
       - task: ':lib-generate'
       - task: ':lib-sealring'
       - "mkdir -p {{.BUILD_ROOT}}/{{.SOC}}/{{.TARGET}}/zibal/macros/bondpad"

--- a/Taskfile.fpga.yml
+++ b/Taskfile.fpga.yml
@@ -16,9 +16,6 @@ tasks:
   prepare:
     desc: Produces the Verilog file and metadata needed for FPGA operations.
     cmds:
-      - task: ':lib-sbt-publishLocal'
-        vars:
-          project: "modules/elements/vexiiriscv"
       - task: ':lib-generate'
         vars:
           FPGA: "ECPIX5"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -106,9 +106,8 @@ vars:
     -e FPGA_PACKAGE={{.FPGA_PACKAGE}} \
     -e FPGA_FREQUENCY={{.FPGA_FREQUENCY}} \
     -e KLAYOUT_HOME={{.KLAYOUT_HOME}} \
-    -e NAFARR_BASE={{.NAFARR_BASE}} \
     -e ZIBAL_BASE={{.ZIBAL_BASE}} \
-    -e VEXRISCV_ROOT={{.VEXRISCV_ROOT}} \
+    -e NAFARR_BASE={{.NAFARR_BASE}} \
     -e BUILD_ROOT={{.BUILD_ROOT}} \
     -e USER={{.USER}} \
     -e ZEPHYR_SDK_INSTALL_DIR={{.ZEPHYR_SDK_INSTALL_DIR}} \
@@ -123,10 +122,9 @@ env:
   FPGA_FREQUENCY: 50
   OPENFPGALOADER_BOARD: ecpix5_r03
   PDK_ROOT: "{{.PWD}}/pdks"
-  NAFARR_BASE: "{{.PWD}}/modules/elements/nafarr/"
-  ZIBAL_BASE: "{{.PWD}}/modules/elements/zibal/"
-  VEXRISCV_ROOT: "{{.PWD}}/modules/elements/vexriscv/"
-  BUILD_ROOT: "{{.PWD}}/build/"
+  ZIBAL_BASE: "{{.PWD}}/modules/elements/zibal"
+  NAFARR_BASE: "{{.ZIBAL_BASE}}/ext/nafarr"
+  BUILD_ROOT: "{{.PWD}}/build"
   ZEPHYR_SDK_INSTALL_DIR: "/opt/elements/zephyr-sdk-1.0.1"
   GCC: "{{.ZEPHYR_SDK_INSTALL_DIR}}/gnu/riscv64-zephyr-elf/bin/riscv64-zephyr-elf"
   OPENROAD_FLOW_ROOT: "{{.PWD}}/tools/OpenROAD-flow-scripts/flow"
@@ -163,7 +161,6 @@ tasks:
     desc: Downloads and synchronizes all required dependencies.
     cmds:
       - ./repo sync {{if .CI}}-q{{end}}
-      - ./repo forall modules/elements/vexiiriscv -c 'git submodule update --init --recursive'
 
   install:
     desc: Installs all dependencies and prepares the project for FPGA and chip workflows.

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: CERN-OHL-W-2.0
 
-val spinalVersion = "1.14.2"
-
 lazy val root = (project in file("."))
   .settings(
     name := "ElemRV",
@@ -15,19 +13,29 @@ lazy val root = (project in file("."))
       )
     ),
     libraryDependencies ++= Seq(
-      "com.github.spinalhdl" % "spinalhdl-core_2.12" % spinalVersion,
-      "com.github.spinalhdl" % "spinalhdl-lib_2.12" % spinalVersion,
-      compilerPlugin("com.github.spinalhdl" % "spinalhdl-idsl-plugin_2.12" % spinalVersion),
       "org.scalatest" %% "scalatest" % "3.2.5",
       "org.yaml" % "snakeyaml" % "1.8"
     ),
     Compile / scalaSource := baseDirectory.value / "hardware" / "scala",
-    Test / scalaSource := baseDirectory.value / "test" / "scala"
+    Test / scalaSource := baseDirectory.value / "test" / "scala",
+    Test / parallelExecution := false,
+    scalacOptions += s"-Xplugin:${(spinalHdlIdslPlugin / Compile / packageBin).value.getAbsolutePath}",
+    scalacOptions += "-Xplugin-require:idsl-plugin",
+    envVars += ("NAFARR_BASE" -> (nafarr / baseDirectory).value.getAbsolutePath)
   )
-  .dependsOn(nafarr, zibal)
+  .dependsOn(zibal, spinalHdlIdslPlugin, spinalHdlCore, spinalHdlLib, spinalHdlSim)
 
-lazy val nafarr = RootProject(file("modules/elements/nafarr/"))
-lazy val zibal = RootProject(file("modules/elements/zibal/"))
+val zibalPath = sys.env.getOrElse("ZIBAL_PATH", "modules/elements/zibal")
+val nafarrPath = sys.env.getOrElse("NAFARR_PATH", zibalPath + "/ext/nafarr")
+val spinalHdlPath = sys.env.getOrElse("SPINALHDL_PATH", nafarrPath + "/ext/VexiiRiscv/ext/SpinalHDL")
+
+lazy val zibal = RootProject(file(zibalPath))
+lazy val nafarr = RootProject(file(nafarrPath))
+
+lazy val spinalHdlIdslPlugin = ProjectRef(file(spinalHdlPath), "idslplugin")
+lazy val spinalHdlCore = ProjectRef(file(spinalHdlPath), "core")
+lazy val spinalHdlLib = ProjectRef(file(spinalHdlPath), "lib")
+lazy val spinalHdlSim = ProjectRef(file(spinalHdlPath), "sim")
 
 run / connectInput := true
 fork := true

--- a/manifest-nightly.xml
+++ b/manifest-nightly.xml
@@ -11,10 +11,7 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 
 	<default remote="github" sync-j="8" />
 
-	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="main" />
 	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="main" />
-	<project name="SpinalHDL/SpinalCrypto" path="modules/elements/SpinalCrypto" revision="f2a4ae9db5e9434c5589d0651efec8719103498e" />
-	<project name="SpinalHDL/VexiiRiscv" sync-s="true" path="modules/elements/vexiiriscv" revision="03587f948b91f84197ecdbd958ba490977fd5671" />
 	<project name="aesc-silicon/OpenROAD-flow-scripts" path="tools/OpenROAD-flow-scripts" revision="0bcb5dd40908d0313168372454caffc81d6f9b6f" />
 	<project name="antmicro/renode-verilator-integration" path="tools/renode-verilator-integration" revision="c9692ca32c8c160e0c268bd0f5207359cee1626d" />
 	<project name="aesc-silicon/IHP-Open-PDK" sync-s="true" path="pdks/IHP-Open-PDK" revision="16f0fd4b8dd36c694583cfe61d0ecdaf61015c7f" />

--- a/manifest.xml
+++ b/manifest.xml
@@ -11,10 +11,7 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 
 	<default remote="github" sync-j="8" />
 
-	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="5357ef4bcbb7e825c99cc29ccb7304008da60f07" />
 	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="47a333097790cc21b7f1eb34af768bec4bc1f492" />
-	<project name="SpinalHDL/SpinalCrypto" path="modules/elements/SpinalCrypto" revision="f2a4ae9db5e9434c5589d0651efec8719103498e" />
-	<project name="SpinalHDL/VexiiRiscv" sync-s="true" path="modules/elements/vexiiriscv" revision="03587f948b91f84197ecdbd958ba490977fd5671" />
 	<project name="aesc-silicon/OpenROAD-flow-scripts" path="tools/OpenROAD-flow-scripts" revision="0bcb5dd40908d0313168372454caffc81d6f9b6f" />
 	<project name="antmicro/renode-verilator-integration" path="tools/renode-verilator-integration" revision="c9692ca32c8c160e0c268bd0f5207359cee1626d" />
 	<project name="aesc-silicon/IHP-Open-PDK" sync-s="true" path="pdks/IHP-Open-PDK" revision="6e8e108025798bef4a150f8692e2fd9a0bafd87b" />

--- a/manifest.xml
+++ b/manifest.xml
@@ -11,7 +11,7 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 
 	<default remote="github" sync-j="8" />
 
-	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="3ae591cff0c6a6b8737d0a4aaf1f5111cd5d3620" />
+	<project name="aesc-silicon/elements-zibal" sync-s="true" path="modules/elements/zibal" revision="3ae591cff0c6a6b8737d0a4aaf1f5111cd5d3620" />
 	<project name="aesc-silicon/OpenROAD-flow-scripts" path="tools/OpenROAD-flow-scripts" revision="0bcb5dd40908d0313168372454caffc81d6f9b6f" />
 	<project name="antmicro/renode-verilator-integration" path="tools/renode-verilator-integration" revision="c9692ca32c8c160e0c268bd0f5207359cee1626d" />
 	<project name="aesc-silicon/IHP-Open-PDK" sync-s="true" path="pdks/IHP-Open-PDK" revision="6e8e108025798bef4a150f8692e2fd9a0bafd87b" />

--- a/manifest.xml
+++ b/manifest.xml
@@ -11,7 +11,7 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 
 	<default remote="github" sync-j="8" />
 
-	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="47a333097790cc21b7f1eb34af768bec4bc1f492" />
+	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="3ae591cff0c6a6b8737d0a4aaf1f5111cd5d3620" />
 	<project name="aesc-silicon/OpenROAD-flow-scripts" path="tools/OpenROAD-flow-scripts" revision="0bcb5dd40908d0313168372454caffc81d6f9b6f" />
 	<project name="antmicro/renode-verilator-integration" path="tools/renode-verilator-integration" revision="c9692ca32c8c160e0c268bd0f5207359cee1626d" />
 	<project name="aesc-silicon/IHP-Open-PDK" sync-s="true" path="pdks/IHP-Open-PDK" revision="6e8e108025798bef4a150f8692e2fd9a0bafd87b" />

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")


### PR DESCRIPTION
Zibal and Nafarr now ship all required projects. Remove these deps from the manifest, Taskfile, build.sbt.