### PR TITLE
Add CoreMark Benchmark Firmware

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,7 @@ labels: ["bug"]
 body:
   - type: markdown
     attributes:
-      value: |
+      value: >-
         Before filing: if this is about an IP core or its driver, it belongs in
         [Nafarr](https://github.com/aesc-silicon/elements-nafarr/issues). If it is
         about a platform or a build flow, it belongs in

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -8,7 +8,7 @@ labels: ["documentation"]
 body:
   - type: markdown
     attributes:
-      value: |
+      value: >-
         Documentation issues are genuinely useful — a wrong register offset or a
         setup step that does not work costs somebody an afternoon. Small fixes are
         also a good first pull request if you would rather send one directly.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,7 +8,7 @@ labels: ["enhancement"]
 body:
   - type: markdown
     attributes:
-      value: |
+      value: >-
         A new **IP core** belongs in
         [Nafarr](https://github.com/aesc-silicon/elements-nafarr/issues), and a new
         **platform or build-flow** capability belongs in

--- a/.github/workflows/docs-check.yaml
+++ b/.github/workflows/docs-check.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           repository: aesc-silicon/elements-nafarr
           ref: main
-          path: modules/elements/nafarr
+          path: modules/elements/zibal/ext/nafarr
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'

--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           repository: aesc-silicon/elements-nafarr
           ref: main
-          path: modules/elements/nafarr
+          path: modules/elements/zibal/ext/nafarr
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ project is split across four repositories that are assembled into one workspace:
 
 | I want to change | Repository | Path in the workspace |
 | --- | --- | --- |
-| An IP core, its register map, its tests, its documentation, its bare-metal driver or its Renode model | [elements-nafarr](https://github.com/aesc-silicon/elements-nafarr) | `modules/elements/nafarr` |
+| An IP core, its register map, its tests, its documentation, its bare-metal driver or its Renode model | [elements-nafarr](https://github.com/aesc-silicon/elements-nafarr) | `modules/elements/zibal/ext/nafarr` |
 | A platform (Hydrogen, Carbon, Nitrogen), the interconnect, or the EDA/build tooling — OpenROAD, Lattice, OpenOCD, report generators | [elements-zibal](https://github.com/aesc-silicon/elements-zibal) | `modules/elements/zibal` |
 | An SoC variant, a chip top level, a Taskfile flow, the platform documentation, or board bring-up | **ElemRV** (this one) | the workspace root |
 | A Zephyr driver, board or devicetree binding | [elements-zephyr](https://github.com/aesc-silicon/elements-zephyr) | `modules/elements/zephyr` |

--- a/Taskfile.baremetal.yml
+++ b/Taskfile.baremetal.yml
@@ -9,9 +9,9 @@ vars:
   arch:
     sh: |
       case "{{.SOC}}" in
-        ElemRV-H) echo "rv32i_zicsr" ;;
-        ElemRV-C) echo "rv32imc_zicsr" ;;
-        ElemRV-N) echo "rv32imc_zicsr_zicntr_zihpm" ;;
+        ElemRV-H) echo "rv32i_zicsr_zifencei" ;;
+        ElemRV-C) echo "rv32imc_zicsr_zifencei" ;;
+        ElemRV-N) echo "rv32imc_zicsr_zifencei_zicntr_zihpm" ;;
         *) echo ""; echo "Unknown SOC: {{.SOC}}" >&2; exit 1 ;;
       esac
 

--- a/Taskfile.coremark.yml
+++ b/Taskfile.coremark.yml
@@ -9,9 +9,9 @@ vars:
   arch:
     sh: |
       case "{{.SOC}}" in
-        ElemRV-H) echo "rv32i_zicsr" ;;
-        ElemRV-C) echo "rv32imc_zicsr" ;;
-        ElemRV-N) echo "rv32imc_zicsr_zicntr_zihpm" ;;
+        ElemRV-H) echo "rv32i_zicsr_zifencei" ;;
+        ElemRV-C) echo "rv32imc_zicsr_zifencei" ;;
+        ElemRV-N) echo "rv32imc_zicsr_zifencei_zicntr_zihpm" ;;
         *) echo ""; echo "Unknown SOC: {{.SOC}}" >&2; exit 1 ;;
       esac
 

--- a/Taskfile.coremark.yml
+++ b/Taskfile.coremark.yml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2026 aesc silicon
+#
+# SPDX-License-Identifier: CERN-OHL-W-2.0
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+
+version: '3'
+
+vars:
+  arch:
+    sh: |
+      case "{{.SOC}}" in
+        ElemRV-H) echo "rv32i_zicsr" ;;
+        ElemRV-C) echo "rv32imc_zicsr" ;;
+        ElemRV-N) echo "rv32imc_zicsr_zicntr_zihpm" ;;
+        *) echo ""; echo "Unknown SOC: {{.SOC}}" >&2; exit 1 ;;
+      esac
+
+tasks:
+  compile:
+    desc: Compiles the CoreMark benchmark firmware.
+    preconditions:
+      - sh: 'test -f {{.BUILD_ROOT}}/{{.SOC}}/firmware/storages.yaml'
+        msg: "Design not generated. Run 'task SOC={{.SOC}} asic:prepare' first."
+    cmds:
+      - task: ':lib-baremetal-firmware'
+        vars:
+          app: "bootrom"
+      - task: ':lib-baremetal-firmware'
+        vars:
+          app: "coremark"
+          makefile: "coremark"
+      - "{{.RUN}} './software/{{.package}}/gen_coremark_container.sh'"
+      - "{{.RUN}} 'ln -sf {{.BUILD_ROOT}}/{{.SOC}}/firmware/coremark_container.img {{.BUILD_ROOT}}/{{.SOC}}/firmware/image_container.img'"
+
+  debug:
+    desc: Attach GDB over JTAG and debug the CoreMark benchmark firmware.
+    cmds:
+      - "{{.RUN}} '${GCC}-gdb {{.BUILD_ROOT}}/{{.SOC}}/firmware/coremark/output.elf -x modules/elements/zibal/gdb/debug.cmd'"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -14,6 +14,8 @@ includes:
     taskfile: ./Taskfile.fpga.yml
   baremetal:
     taskfile: ./Taskfile.baremetal.yml
+  coremark:
+    taskfile: ./Taskfile.coremark.yml
   zephyr:
     taskfile: ./Taskfile.zephyr.yml
   flash:
@@ -108,6 +110,7 @@ vars:
     -e KLAYOUT_HOME={{.KLAYOUT_HOME}} \
     -e ZIBAL_BASE={{.ZIBAL_BASE}} \
     -e NAFARR_BASE={{.NAFARR_BASE}} \
+    -e COREMARK_BASE={{.COREMARK_BASE}} \
     -e BUILD_ROOT={{.BUILD_ROOT}} \
     -e USER={{.USER}} \
     -e ZEPHYR_SDK_INSTALL_DIR={{.ZEPHYR_SDK_INSTALL_DIR}} \
@@ -124,6 +127,7 @@ env:
   PDK_ROOT: "{{.PWD}}/pdks"
   ZIBAL_BASE: "{{.PWD}}/modules/elements/zibal"
   NAFARR_BASE: "{{.ZIBAL_BASE}}/ext/nafarr"
+  COREMARK_BASE: "{{.PWD}}/tools/coremark"
   BUILD_ROOT: "{{.PWD}}/build"
   ZEPHYR_SDK_INSTALL_DIR: "/opt/elements/zephyr-sdk-1.0.1"
   GCC: "{{.ZEPHYR_SDK_INSTALL_DIR}}/gnu/riscv64-zephyr-elf/bin/riscv64-zephyr-elf"

--- a/Taskfile.zephyr.yml
+++ b/Taskfile.zephyr.yml
@@ -9,9 +9,9 @@ vars:
   arch:
     sh: |
       case "{{.SOC}}" in
-        ElemRV-H) echo "rv32i_zicsr" ;;
-        ElemRV-C) echo "rv32imc_zicsr" ;;
-        ElemRV-N) echo "rv32imc_zicsr_zicntr_zihpm" ;;
+        ElemRV-H) echo "rv32i_zicsr_zifencei" ;;
+        ElemRV-C) echo "rv32imc_zicsr_zifencei" ;;
+        ElemRV-N) echo "rv32imc_zicsr_zifencei_zicntr_zihpm" ;;
         *) echo ""; echo "Unknown SOC: {{.SOC}}" >&2; exit 1 ;;
       esac
   zephyr_board:

--- a/docs/source/hardware
+++ b/docs/source/hardware
@@ -1,1 +1,1 @@
-../../modules/elements/nafarr/docs/source/hardware
+../../modules/elements/zibal/ext/nafarr/docs/source/hardware

--- a/docs/source/nonmetals/index.rst
+++ b/docs/source/nonmetals/index.rst
@@ -310,6 +310,76 @@ for higher-tier platforms is planned.
      - TBD
 
 
+Performance
+***********
+
+CoreMark 1.0, measured on FPGA with the port in ``software/<soc>/coremark``.
+Scores are dominated by memory and ISA rather than by the pipeline: Hydrogen has
+no instruction cache and no hardware multiply, so every fetch is a SPI flash
+transaction and every multiply a libgcc call. Carbon adds both, which accounts
+for almost all of its advantage. Nitrogen's further gain comes from the data
+cache, branch prediction and HyperRAM, and is much smaller because the core is
+no longer starved for instructions.
+
+.. list-table:: CoreMark
+   :header-rows: 1
+   :stub-columns: 1
+   :align: left
+
+   * -
+     - CoreMark/MHz
+     - Iterations/s
+     - Clock
+     - ISA
+     - Executed from
+   * - Hydrogen
+     - 0.005
+     - 0.24
+     - 50 MHz
+     - rv32i_zicsr_zifencei
+     - XIP flash
+   * - Carbon
+     - 1.590
+     - 79.48
+     - 50 MHz
+     - rv32imc_zicsr_zifencei
+     - XIP flash
+   * - Nitrogen
+     - 2.360
+     - 70.80
+     - 30 MHz
+     - rv32imc_zicsr_zifencei_zicntr_zihpm
+     - HyperRAM
+   * - Oxygen
+     -
+     -
+     -
+     -
+     -
+   * - Phosphorus
+     -
+     -
+     -
+     -
+     -
+   * - Sulfur
+     -
+     -
+     -
+     -
+     -
+
+Built with GCC 14.3.0 and ``-O2 -march=<isa> -mabi=ilp32``, ``MEM_METHOD=MEM_STACK``,
+iterations auto-scaled so every run exceeds the ten seconds EEMBC requires. The
+ports have no floating point, so CoreMark's own ``Iterations/Sec`` line is
+computed from a truncated whole-second time; the figures above are derived from
+the raw tick count and timer frequency that ``portable_fini()`` prints.
+
+Nitrogen additionally reports ``mcycle`` and ``minstret``, giving 423,714 cycles
+and 313,653 instructions per iteration, an IPC of 0.74. Its cycle count matches
+the machine timer to seven digits, confirming that the CPU and the timer share
+one clock.
+
 See the available platforms for detailed specifications and usage instructions.
 
 .. toctree::

--- a/hardware/scala/elemrv_c/ElemRV.scala
+++ b/hardware/scala/elemrv_c/ElemRV.scala
@@ -18,7 +18,6 @@ import nafarr.peripherals.io.pwm.{TileLinkPwm, Pwm, PwmCtrl}
 import nafarr.peripherals.com.uart.{TileLinkUart, Uart, UartCtrl}
 import nafarr.peripherals.com.i2c.{TileLinkI2cController, I2c, I2cControllerCtrl}
 import nafarr.peripherals.pinmux.{TileLinkPinmux, Pinmux, PinmuxCtrl}
-import nafarr.crypto.crc.{TileLinkCrc32, Crc32Ctrl}
 import nafarr.crypto.prng.{TileLinkPrng, PrngCtrl}
 
 object ElemRV {

--- a/hardware/scala/elemrv_c/SG13CMOS5L/ECPIX5/ECPIX5.scala
+++ b/hardware/scala/elemrv_c/SG13CMOS5L/ECPIX5/ECPIX5.scala
@@ -16,6 +16,7 @@ import nafarr.system.reset.ResetControllerCtrl._
 import nafarr.system.clock._
 import nafarr.system.clock.ClockControllerCtrl._
 import nafarr.blackboxes.lattice.ecp5._
+import nafarr.memory.ocram.TileLinkOnChipRam
 import nafarr.memory.ocram.ihp.TileLinkIhpOnChipRam
 import nafarr.memory.hyperbus.sim.W956A8MBYA
 import nafarr.memory.spi.MT25Q
@@ -130,7 +131,7 @@ case class ECPIX5Top() extends Component {
       clockCtrl
     },
     onChipRamLogic = (parameter: TileLinkParameter, ramSize: BigInt) => {
-      val ram = TileLinkIhpOnChipRam.OnePort(parameter, ramSize.toInt)
+      val ram = TileLinkOnChipRam(p = parameter, size = ramSize)
       (ram, ram.io.bus)
     }
   )

--- a/hardware/scala/elemrv_c/SG13CMOS5L/SG13CMOS5L.scala
+++ b/hardware/scala/elemrv_c/SG13CMOS5L/SG13CMOS5L.scala
@@ -214,6 +214,9 @@ object SG13CMOS5LGenerate extends ElementsApp {
     BaremetalTools
       .Header(elementsConfig, "demo")
       .generate(top.soc.baremetalDevices, top.soc.baremetalIrqs, top.soc.baremetalErrors)
+    BaremetalTools
+      .Header(elementsConfig, "coremark")
+      .generate(top.soc.baremetalDevices, top.soc.baremetalIrqs, top.soc.baremetalErrors)
     RenodeTools.dumpCosimManifest(top.soc, elementsConfig.cosimManifest)
 
     top

--- a/hardware/scala/elemrv_c/SG13CMOS5L/SG13CMOS5L.scala
+++ b/hardware/scala/elemrv_c/SG13CMOS5L/SG13CMOS5L.scala
@@ -13,6 +13,7 @@ import nafarr.system.reset._
 import nafarr.system.clock._
 import nafarr.blackboxes.ihp.sg13cmos5l._
 import nafarr.blackboxes.ihp.common._
+import nafarr.memory.ocram.TileLinkOnChipRam
 import nafarr.memory.ocram.ihp.TileLinkIhpOnChipRam
 import nafarr.memory.hyperbus.sim.W956A8MBYA
 import nafarr.memory.spi.MT25Q
@@ -117,7 +118,7 @@ case class SG13CMOS5LTop() extends Component {
       clockCtrl
     },
     onChipRamLogic = (parameter: TileLinkParameter, ramSize: BigInt) => {
-      val ram = TileLinkIhpOnChipRam.OnePort(parameter, ramSize.toInt)
+      val ram = TileLinkOnChipRam(p = parameter, size = ramSize)
       (ram, ram.io.bus)
     }
   )
@@ -243,7 +244,7 @@ object SG13CMOS5LGenerate extends ElementsApp {
   val sramNorthX =
     scala.math.floor((chip.coreArea._1 + chip.coreArea._3 - 416.64) / 0.96) * 48 / 100
   chip.addMacro(
-    report.toplevel.soc.system.onChipRam.ctrl.asInstanceOf[TileLinkIhpOnChipRam.OnePort].rams(0),
+    report.toplevel.soc.system.onChipRam.ctrl.asInstanceOf[TileLinkOnChipRam].rams(0),
     sramNorthX,
     sramNorthY,
     "R0",

--- a/hardware/scala/elemrv_c/elemrv_c_cosim.resc
+++ b/hardware/scala/elemrv_c/elemrv_c_cosim.resc
@@ -11,10 +11,10 @@ $bin ?= @build/app.bin
 $cosimdir ?= @build/ElemRV-C/SG13CMOS5L/cosim
 
 # Functional peripheral models that stay in Renode (the rest are co-simulated RTL).
-i @modules/elements/nafarr/hardware/scala/nafarr/peripherals/com/uart/UartCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/system/mtimer/MachineTimerCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/system/plic/PlicCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/memory/spi/SpiXipControllerCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/peripherals/com/uart/UartCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/system/mtimer/MachineTimerCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/system/plic/PlicCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/memory/spi/SpiXipControllerCtrl.cs
 
 mach create "elemrv_c_cosim"
 machine LoadPlatformDescription @hardware/scala/elemrv_c/elemrv_c_cosim.repl

--- a/hardware/scala/elemrv_c/elemrv_c_emul.resc
+++ b/hardware/scala/elemrv_c/elemrv_c_emul.resc
@@ -10,15 +10,15 @@
 $bin ?= @build/app.bin
 
 # Compile and register the custom Nafarr peripheral models (live next to their .scala).
-i @modules/elements/nafarr/hardware/scala/nafarr/peripherals/io/gpio/GpioCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/peripherals/com/uart/UartCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/peripherals/pinmux/PinmuxCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/crypto/prng/PrngCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/system/mtimer/MachineTimerCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/system/plic/PlicCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/system/syscon/Syscon.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/system/clock/ClockControllerCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/memory/spi/SpiXipControllerCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/peripherals/io/gpio/GpioCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/peripherals/com/uart/UartCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/peripherals/pinmux/PinmuxCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/crypto/prng/PrngCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/system/mtimer/MachineTimerCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/system/plic/PlicCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/system/syscon/Syscon.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/system/clock/ClockControllerCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/memory/spi/SpiXipControllerCtrl.cs
 
 mach create "elemrv_c"
 machine LoadPlatformDescription @hardware/scala/elemrv_c/elemrv_c_emul.repl

--- a/hardware/scala/elemrv_h/SG13CMOS5L/ECPIX5/ECPIX5.scala
+++ b/hardware/scala/elemrv_h/SG13CMOS5L/ECPIX5/ECPIX5.scala
@@ -16,6 +16,7 @@ import nafarr.system.reset.ResetControllerCtrl._
 import nafarr.system.clock._
 import nafarr.system.clock.ClockControllerCtrl._
 import nafarr.blackboxes.lattice.ecp5._
+import nafarr.memory.ocram.TileLinkOnChipRam
 import nafarr.memory.ocram.ihp.TileLinkIhpOnChipRam
 import nafarr.memory.hyperbus.sim.W956A8MBYA
 import nafarr.memory.spi.MT25Q
@@ -129,7 +130,7 @@ case class ECPIX5Top() extends Component {
       clockCtrl
     },
     onChipRamLogic = (parameter: TileLinkParameter, ramSize: BigInt) => {
-      val ram = TileLinkIhpOnChipRam.OnePort(parameter, ramSize.toInt)
+      val ram = TileLinkOnChipRam(p = parameter, size = ramSize)
       (ram, ram.io.bus)
     }
   )

--- a/hardware/scala/elemrv_h/SG13CMOS5L/SG13CMOS5L.scala
+++ b/hardware/scala/elemrv_h/SG13CMOS5L/SG13CMOS5L.scala
@@ -213,6 +213,10 @@ object SG13CMOS5LGenerate extends ElementsApp {
     BaremetalTools
       .Header(elementsConfig, "demo")
       .generate(top.soc.baremetalDevices, top.soc.baremetalIrqs, top.soc.baremetalErrors)
+    BaremetalTools
+      .Header(elementsConfig, "coremark")
+      .generate(top.soc.baremetalDevices, top.soc.baremetalIrqs, top.soc.baremetalErrors)
+
     RenodeTools.dumpCosimManifest(top.soc, elementsConfig.cosimManifest)
 
     top

--- a/hardware/scala/elemrv_h/SG13CMOS5L/SG13CMOS5L.scala
+++ b/hardware/scala/elemrv_h/SG13CMOS5L/SG13CMOS5L.scala
@@ -13,6 +13,7 @@ import nafarr.system.reset._
 import nafarr.system.clock._
 import nafarr.blackboxes.ihp.sg13cmos5l._
 import nafarr.blackboxes.ihp.common._
+import nafarr.memory.ocram.TileLinkOnChipRam
 import nafarr.memory.ocram.ihp.TileLinkIhpOnChipRam
 import nafarr.memory.hyperbus.sim.W956A8MBYA
 import nafarr.memory.spi.MT25Q
@@ -116,7 +117,7 @@ case class SG13CMOS5LTop() extends Component {
       clockCtrl
     },
     onChipRamLogic = (parameter: TileLinkParameter, ramSize: BigInt) => {
-      val ram = TileLinkIhpOnChipRam.OnePort(parameter, ramSize.toInt)
+      val ram = TileLinkOnChipRam(p = parameter, size = ramSize)
       (ram, ram.io.bus)
     }
   )
@@ -243,7 +244,7 @@ object SG13CMOS5LGenerate extends ElementsApp {
   val sramNorthY = chip.coreArea._4 - sramHeight - 30.24
   val sramNorthX = chip.coreArea._1 + 20.16
   chip.addMacro(
-    report.toplevel.soc.system.onChipRam.ctrl.asInstanceOf[TileLinkIhpOnChipRam.OnePort].rams(0),
+    report.toplevel.soc.system.onChipRam.ctrl.asInstanceOf[TileLinkOnChipRam].rams(0),
     sramNorthX,
     sramNorthY,
     "R0",

--- a/hardware/scala/elemrv_h/elemrv_h_cosim.resc
+++ b/hardware/scala/elemrv_h/elemrv_h_cosim.resc
@@ -11,10 +11,10 @@ $bin ?= @build/app.bin
 $cosimdir ?= @build/ElemRV-H/SG13CMOS5L/cosim
 
 # Functional peripheral models that stay in Renode (the rest are co-simulated RTL).
-i @modules/elements/nafarr/hardware/scala/nafarr/peripherals/com/uart/UartCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/system/mtimer/MachineTimerCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/system/plic/PlicCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/memory/spi/SpiXipControllerCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/peripherals/com/uart/UartCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/system/mtimer/MachineTimerCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/system/plic/PlicCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/memory/spi/SpiXipControllerCtrl.cs
 
 mach create "elemrv_h_cosim"
 machine LoadPlatformDescription @hardware/scala/elemrv_h/elemrv_h_cosim.repl

--- a/hardware/scala/elemrv_h/elemrv_h_emul.resc
+++ b/hardware/scala/elemrv_h/elemrv_h_emul.resc
@@ -10,15 +10,15 @@
 $bin ?= @build/app.bin
 
 # Compile and register the custom Nafarr peripheral models (live next to their .scala).
-i @modules/elements/nafarr/hardware/scala/nafarr/peripherals/io/gpio/GpioCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/peripherals/com/uart/UartCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/peripherals/pinmux/PinmuxCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/crypto/prng/PrngCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/system/mtimer/MachineTimerCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/system/plic/PlicCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/system/syscon/Syscon.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/system/clock/ClockControllerCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/memory/spi/SpiXipControllerCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/peripherals/io/gpio/GpioCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/peripherals/com/uart/UartCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/peripherals/pinmux/PinmuxCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/crypto/prng/PrngCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/system/mtimer/MachineTimerCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/system/plic/PlicCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/system/syscon/Syscon.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/system/clock/ClockControllerCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/memory/spi/SpiXipControllerCtrl.cs
 
 mach create "elemrv_h"
 machine LoadPlatformDescription @hardware/scala/elemrv_h/elemrv_h_emul.repl

--- a/hardware/scala/elemrv_n/SG13CMOS5L/ECPIX5/ECPIX5.scala
+++ b/hardware/scala/elemrv_n/SG13CMOS5L/ECPIX5/ECPIX5.scala
@@ -16,6 +16,7 @@ import nafarr.system.reset.ResetControllerCtrl._
 import nafarr.system.clock._
 import nafarr.system.clock.ClockControllerCtrl._
 import nafarr.blackboxes.lattice.ecp5._
+import nafarr.memory.ocram.TileLinkOnChipRam
 import nafarr.memory.ocram.ihp.TileLinkIhpOnChipRam
 import nafarr.memory.hyperbus.sim.W956A8MBYA
 import nafarr.memory.spi.MT25Q
@@ -178,7 +179,7 @@ case class ECPIX5Top() extends Component {
       clockCtrl
     },
     onChipRamLogic = (parameter: TileLinkParameter, ramSize: BigInt) => {
-      val ram = TileLinkIhpOnChipRam.OnePort(parameter, ramSize.toInt)
+      val ram = TileLinkOnChipRam(p = parameter, size = ramSize)
       (ram, ram.io.bus)
     }
   )

--- a/hardware/scala/elemrv_n/SG13CMOS5L/SG13CMOS5L.scala
+++ b/hardware/scala/elemrv_n/SG13CMOS5L/SG13CMOS5L.scala
@@ -299,10 +299,10 @@ object SG13CMOS5LGenerate extends ElementsApp {
     top.setDefinitionName(topCellName)
 
     BaremetalTools
-      .Header(elementsConfig, "bootrom")
+      .Header(elementsConfig, "demo")
       .generate(top.soc.baremetalDevices, top.soc.baremetalIrqs, top.soc.baremetalErrors)
     BaremetalTools
-      .Header(elementsConfig, "demo")
+      .Header(elementsConfig, "coremark")
       .generate(top.soc.baremetalDevices, top.soc.baremetalIrqs, top.soc.baremetalErrors)
     RenodeTools.dumpCosimManifest(top.soc, elementsConfig.cosimManifest)
 

--- a/hardware/scala/elemrv_n/elemrv_n_cosim.resc
+++ b/hardware/scala/elemrv_n/elemrv_n_cosim.resc
@@ -11,12 +11,12 @@ $bin ?= @build/app.bin
 $cosimdir ?= @build/ElemRV-N/SG13CMOS5L/cosim
 
 # Functional peripheral models that stay in Renode (the rest are co-simulated RTL).
-i @modules/elements/nafarr/hardware/scala/nafarr/peripherals/com/uart/UartCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/system/mtimer/MachineTimerCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/system/plic/PlicCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/memory/spi/SpiXipControllerCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/memory/hyperbus/HyperBusCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/system/timer/TimerCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/peripherals/com/uart/UartCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/system/mtimer/MachineTimerCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/system/plic/PlicCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/memory/spi/SpiXipControllerCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/memory/hyperbus/HyperBusCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/system/timer/TimerCtrl.cs
 
 mach create "elemrv_n_cosim"
 machine LoadPlatformDescription @hardware/scala/elemrv_n/elemrv_n_cosim.repl

--- a/hardware/scala/elemrv_n/elemrv_n_emul.resc
+++ b/hardware/scala/elemrv_n/elemrv_n_emul.resc
@@ -10,16 +10,16 @@
 $bin ?= @build/app.bin
 
 # Compile and register the custom Nafarr peripheral models (live next to their .scala).
-i @modules/elements/nafarr/hardware/scala/nafarr/peripherals/io/gpio/GpioCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/peripherals/com/uart/UartCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/peripherals/pinmux/PinmuxCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/crypto/prng/PrngCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/system/mtimer/MachineTimerCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/system/plic/PlicCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/system/syscon/Syscon.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/system/clock/ClockControllerCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/memory/spi/SpiXipControllerCtrl.cs
-i @modules/elements/nafarr/hardware/scala/nafarr/memory/hyperbus/HyperBusCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/peripherals/io/gpio/GpioCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/peripherals/com/uart/UartCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/peripherals/pinmux/PinmuxCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/crypto/prng/PrngCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/system/mtimer/MachineTimerCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/system/plic/PlicCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/system/syscon/Syscon.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/system/clock/ClockControllerCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/memory/spi/SpiXipControllerCtrl.cs
+i @modules/elements/zibal/ext/nafarr/hardware/scala/nafarr/memory/hyperbus/HyperBusCtrl.cs
 
 mach create "elemrv_n"
 machine LoadPlatformDescription @hardware/scala/elemrv_n/elemrv_n_emul.repl

--- a/manifest-nightly.xml
+++ b/manifest-nightly.xml
@@ -14,5 +14,6 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="main" />
 	<project name="aesc-silicon/OpenROAD-flow-scripts" path="tools/OpenROAD-flow-scripts" revision="0bcb5dd40908d0313168372454caffc81d6f9b6f" />
 	<project name="antmicro/renode-verilator-integration" path="tools/renode-verilator-integration" revision="c9692ca32c8c160e0c268bd0f5207359cee1626d" />
+	<project name="eembc/coremark" path="tools/coremark" revision="1f483d5b8316753a742cbf5590caf5bd0a4e4777" />
 	<project name="aesc-silicon/IHP-Open-PDK" sync-s="true" path="pdks/IHP-Open-PDK" revision="16f0fd4b8dd36c694583cfe61d0ecdaf61015c7f" />
 </manifest>

--- a/manifest.xml
+++ b/manifest.xml
@@ -11,7 +11,7 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 
 	<default remote="github" sync-j="8" />
 
-	<project name="aesc-silicon/elements-zibal" sync-s="true" path="modules/elements/zibal" revision="3ae591cff0c6a6b8737d0a4aaf1f5111cd5d3620" />
+	<project name="aesc-silicon/elements-zibal" sync-s="true" path="modules/elements/zibal" revision="e3e011dfbf1fded39bb7934a59e55adff1a0c4ea" />
 	<project name="aesc-silicon/OpenROAD-flow-scripts" path="tools/OpenROAD-flow-scripts" revision="0bcb5dd40908d0313168372454caffc81d6f9b6f" />
 	<project name="antmicro/renode-verilator-integration" path="tools/renode-verilator-integration" revision="c9692ca32c8c160e0c268bd0f5207359cee1626d" />
 	<project name="eembc/coremark" path="tools/coremark" revision="1f483d5b8316753a742cbf5590caf5bd0a4e4777" />

--- a/manifest.xml
+++ b/manifest.xml
@@ -14,5 +14,6 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 	<project name="aesc-silicon/elements-zibal" sync-s="true" path="modules/elements/zibal" revision="3ae591cff0c6a6b8737d0a4aaf1f5111cd5d3620" />
 	<project name="aesc-silicon/OpenROAD-flow-scripts" path="tools/OpenROAD-flow-scripts" revision="0bcb5dd40908d0313168372454caffc81d6f9b6f" />
 	<project name="antmicro/renode-verilator-integration" path="tools/renode-verilator-integration" revision="c9692ca32c8c160e0c268bd0f5207359cee1626d" />
+	<project name="eembc/coremark" path="tools/coremark" revision="1f483d5b8316753a742cbf5590caf5bd0a4e4777" />
 	<project name="aesc-silicon/IHP-Open-PDK" sync-s="true" path="pdks/IHP-Open-PDK" revision="6e8e108025798bef4a150f8692e2fd9a0bafd87b" />
 </manifest>

--- a/software/elemrv_c/coremark/core_portme.c
+++ b/software/elemrv_c/coremark/core_portme.c
@@ -1,0 +1,215 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdarg.h>
+
+#include "coremark.h"
+#include "core_portme.h"
+
+#include "soc.h"
+#include "uart.h"
+#include "mtimer.h"
+
+#if VALIDATION_RUN
+volatile ee_s32 seed1_volatile = 0x3415;
+volatile ee_s32 seed2_volatile = 0x3415;
+volatile ee_s32 seed3_volatile = 0x66;
+#endif
+#if PERFORMANCE_RUN
+volatile ee_s32 seed1_volatile = 0x0;
+volatile ee_s32 seed2_volatile = 0x0;
+volatile ee_s32 seed3_volatile = 0x66;
+#endif
+#if PROFILE_RUN
+volatile ee_s32 seed1_volatile = 0x8;
+volatile ee_s32 seed2_volatile = 0x8;
+volatile ee_s32 seed3_volatile = 0x8;
+#endif
+volatile ee_s32 seed4_volatile = ITERATIONS;
+volatile ee_s32 seed5_volatile = 0;
+
+ee_u32 default_num_contexts = 1;
+
+static struct uart_driver uart;
+static struct mtimer_driver mtimer;
+
+#define EE_TICKS_PER_SEC MTIMERCTRL_FREQ
+
+/* The machine timer is a 64-bit up-counter split into two 32-bit registers.
+ * Re-read the high word to discard a sample taken across a low-word carry.
+ */
+static unsigned long long mtimer_read(void)
+{
+	unsigned int high, low;
+
+	do {
+		high = mtimer.regs->cnt_high;
+		low = mtimer.regs->cnt_low;
+	} while (high != mtimer.regs->cnt_high);
+
+	return ((unsigned long long)high << 32) | low;
+}
+
+static unsigned long long start_time_val, stop_time_val;
+
+void start_time(void)
+{
+	start_time_val = mtimer_read();
+}
+
+void stop_time(void)
+{
+	stop_time_val = mtimer_read();
+}
+
+CORE_TICKS get_time(void)
+{
+	return (CORE_TICKS)(stop_time_val - start_time_val);
+}
+
+secs_ret time_in_secs(CORE_TICKS ticks)
+{
+	return (secs_ret)(ticks / EE_TICKS_PER_SEC);
+}
+
+/* Minimal formatted output over UART0. CoreMark needs %d, %u, %x, %s and the
+ * 'l' length modifier; %f is never reached because HAS_FLOAT is 0.
+ */
+static void ee_putc(char c)
+{
+	if (c == '\n')
+		uart_putc(&uart, '\r');
+	uart_putc(&uart, (unsigned char)c);
+}
+
+static void ee_puts(const char *s)
+{
+	while (*s)
+		ee_putc(*s++);
+}
+
+static void ee_put_unsigned(unsigned long value, unsigned int base,
+			    unsigned int width, char pad)
+{
+	char buffer[32];
+	unsigned int length = 0;
+
+	do {
+		unsigned int digit = (unsigned int)(value % base);
+
+		buffer[length++] = (char)(digit < 10 ? '0' + digit
+						     : 'a' + digit - 10);
+		value /= base;
+	} while (value);
+
+	while (length < width)
+		buffer[length++] = pad;
+
+	while (length)
+		ee_putc(buffer[--length]);
+}
+
+int ee_printf(const char *fmt, ...)
+{
+	va_list args;
+
+	va_start(args, fmt);
+
+	while (*fmt) {
+		unsigned int width = 0;
+		int is_long = 0;
+		char pad = ' ';
+
+		if (*fmt != '%') {
+			ee_putc(*fmt++);
+			continue;
+		}
+		fmt++;
+
+		if (*fmt == '0') {
+			pad = '0';
+			fmt++;
+		}
+		while (*fmt >= '0' && *fmt <= '9')
+			width = width * 10 + (unsigned int)(*fmt++ - '0');
+		while (*fmt == 'l') {
+			is_long = 1;
+			fmt++;
+		}
+
+		switch (*fmt) {
+		case 'd': {
+			long value = is_long ? va_arg(args, long)
+					     : va_arg(args, int);
+
+			if (value < 0) {
+				ee_putc('-');
+				value = -value;
+			}
+			ee_put_unsigned((unsigned long)value, 10, width, pad);
+			break;
+		}
+		case 'u':
+			ee_put_unsigned(is_long ? va_arg(args, unsigned long)
+						: va_arg(args, unsigned int),
+					10, width, pad);
+			break;
+		case 'x':
+			ee_put_unsigned(is_long ? va_arg(args, unsigned long)
+						: va_arg(args, unsigned int),
+					16, width, pad);
+			break;
+		case 'c':
+			ee_putc((char)va_arg(args, int));
+			break;
+		case 's':
+			ee_puts(va_arg(args, const char *));
+			break;
+		case '%':
+			ee_putc('%');
+			break;
+		default:
+			ee_putc('%');
+			ee_putc(*fmt);
+			break;
+		}
+		fmt++;
+	}
+
+	va_end(args);
+
+	return 0;
+}
+
+void portable_init(core_portable *p, int *argc, char *argv[])
+{
+	(void)argc;
+	(void)argv;
+
+	mtimer_init(&mtimer, MTIMERCTRL_BASE);
+	uart_init(&uart, UART0CTRL_BASE,
+		  UART_CALC_FREQUENCY(UART0CTRL_FREQ, UART0CTRL_BAUD, 8));
+
+	if (sizeof(ee_ptr_int) != sizeof(ee_u8 *))
+		ee_printf("ERROR! ee_ptr_int does not hold a pointer!\n");
+	if (sizeof(ee_u32) != 4)
+		ee_printf("ERROR! ee_u32 is not 32 bits!\n");
+
+	p->portable_id = 1;
+}
+
+void portable_fini(core_portable *p)
+{
+	p->portable_id = 0;
+
+	/* time_in_secs() truncates to whole seconds because this port has no
+	 * floating point. Print the raw inputs so the host can recompute
+	 * iterations/sec exactly.
+	 */
+	ee_printf("Timer ticks      : %lu\n",
+		  (long unsigned)(stop_time_val - start_time_val));
+	ee_printf("Timer frequency  : %lu\n", (long unsigned)EE_TICKS_PER_SEC);
+}

--- a/software/elemrv_c/coremark/core_portme.h
+++ b/software/elemrv_c/coremark/core_portme.h
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CORE_PORTME_H
+#define CORE_PORTME_H
+
+/* ElemRV-H is rv32i_zicsr: no F/D extension and no Zicntr, so floating point
+ * is avoided entirely and timing comes from the machine timer instead of
+ * mcycle. portable_fini() prints the raw tick count and the timer frequency so
+ * the score can be recomputed at full precision on the host.
+ */
+#define HAS_FLOAT  0
+#define HAS_TIME_H 0
+#define USE_CLOCK  0
+#define HAS_STDIO  0
+#define HAS_PRINTF 0
+
+#define COMPILER_VERSION "GCC" __VERSION__
+#ifndef COMPILER_FLAGS
+#define COMPILER_FLAGS FLAGS_STR
+#endif
+#define MEM_LOCATION "STACK"
+
+typedef signed short   ee_s16;
+typedef unsigned short ee_u16;
+typedef signed int     ee_s32;
+typedef double         ee_f32;
+typedef unsigned char  ee_u8;
+typedef unsigned int   ee_u32;
+typedef ee_u32         ee_ptr_int;
+typedef unsigned int   ee_size_t;
+#define NULL ((void *)0)
+
+#define align_mem(x) (void *)(4 + (((ee_ptr_int)(x)-1) & ~3))
+
+#define CORETIMETYPE ee_u32
+typedef ee_u32 CORE_TICKS;
+
+#ifndef SEED_METHOD
+#define SEED_METHOD SEED_VOLATILE
+#endif
+
+#ifndef MEM_METHOD
+#define MEM_METHOD MEM_STACK
+#endif
+
+#ifndef MULTITHREAD
+#define MULTITHREAD 1
+#define USE_PTHREAD 0
+#define USE_FORK    0
+#define USE_SOCKET  0
+#endif
+
+/* No argc/argv from start.s, and _kernel() ignores the return value. */
+#define MAIN_HAS_NOARGC   1
+#define MAIN_HAS_NORETURN 0
+
+extern ee_u32 default_num_contexts;
+
+typedef struct CORE_PORTABLE_S
+{
+	ee_u8 portable_id;
+} core_portable;
+
+void portable_init(core_portable *p, int *argc, char *argv[]);
+void portable_fini(core_portable *p);
+
+#if !defined(PROFILE_RUN) && !defined(PERFORMANCE_RUN) \
+	&& !defined(VALIDATION_RUN)
+#if (TOTAL_DATA_SIZE == 1200)
+#define PROFILE_RUN 1
+#elif (TOTAL_DATA_SIZE == 2000)
+#define PERFORMANCE_RUN 1
+#else
+#define VALIDATION_RUN 1
+#endif
+#endif
+
+int ee_printf(const char *fmt, ...);
+
+#endif /* CORE_PORTME_H */

--- a/software/elemrv_c/coremark/kernel.c
+++ b/software/elemrv_c/coremark/kernel.c
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "soc.h"
+#include "uart.h"
+
+extern void hang(void);
+extern int main(void);
+
+/* start.s jumps here once bss is cleared and the stack is set up. Interrupts
+ * stay disabled for the whole run so nothing perturbs the measurement.
+ */
+void _kernel(void)
+{
+	struct uart_driver uart;
+
+	/* Banner before the benchmark starts: CoreMark itself prints nothing
+	 * until the run completes, which takes a while.
+	 */
+	uart_init(&uart, UART0CTRL_BASE,
+		  UART_CALC_FREQUENCY(UART0CTRL_FREQ, UART0CTRL_BAUD, 8));
+	uart_puts(&uart, (unsigned char *)"\r\nCoreMark starting...\r\n");
+
+	main();
+
+	hang();
+}
+
+/* Referenced by _irq_wrapper in start.s. Unreachable while interrupts are
+ * disabled, but the symbol is needed because the link uses --no-undefined.
+ */
+void isr_handle(unsigned int mcause)
+{
+	(void)mcause;
+}

--- a/software/elemrv_c/coremark/kernel.ld
+++ b/software/elemrv_c/coremark/kernel.ld
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Specify the memory areas */
+
+MEMORY
+{
+	OCRAM (xrw): ORIGIN = 0x80000000, LENGTH = 8k
+	FLASH (xr ): ORIGIN = 0xA0001000, LENGTH = 512k
+}
+stack_size = 8k;
+heap_size = 0;
+
+/* define beginning and ending of stack */
+__stack_start = ORIGIN(OCRAM) + LENGTH(OCRAM);
+__stack_end = __stack_start - stack_size;
+
+ENTRY(_head)
+
+SECTIONS {
+	.text : {
+		 KEEP(*(.text.head))
+		*(.text .text.*)
+	} > FLASH
+
+	.irs_handler : {
+		*(.irs_handler)
+	} > FLASH
+
+	.rodata : {
+		*(.rodata .rodata.*)
+		*(.srodata .srodata.*)
+	} > FLASH
+
+	.data : {
+		. = ALIGN(4);
+		__data_start = . ;
+		*(.data .data.*)
+		*(.sdata .sdata.*)
+		. = ALIGN(4);
+		__data_end = . ;
+	} > OCRAM AT> FLASH
+	__data_load = LOADADDR(.data);
+
+	.bss (NOLOAD) : {
+		__bss_start = . ;
+		*(.bss .bss.*)
+		*(COMMON)
+		*(.sbss .sbss.*)
+		__bss_end = . ;
+	} > OCRAM
+}

--- a/software/elemrv_c/coremark/start.s
+++ b/software/elemrv_c/coremark/start.s
@@ -1,0 +1,146 @@
+/*
+ * SPDX-FileCopyrightText: 2025 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+.equ REGBYTES, 0x4
+
+.section .text
+.global hang
+.global init_trap
+.global interrupt_enable
+.global interrupt_disable
+.extern isr_handle
+.global _head
+_head:
+	li	a0, 1
+	jal	gpio_set_pin
+
+	jal	_init_data
+	jal	_init_bss
+
+	la	sp, __stack_start
+	j	_kernel
+
+hang:
+	nop
+	beqz	zero, hang
+
+init_trap:
+	la	t0, _irq_wrapper
+	csrw	mtvec, t0
+	ret
+
+_init_data:
+	la	t0, __data_load
+	la	t1, __data_start
+	la	t2, __data_end
+	beq	t1, t2, data_end
+data_head:
+	lw	t3, 0(t0)
+	sw	t3, 0(t1)
+	addi	t0, t0, 4
+	addi	t1, t1, 4
+	bltu	t1, t2, data_head
+data_end:
+	ret
+
+_init_bss:
+	la	t0, __bss_start
+	la	t1, __bss_end
+	beq	t0, t1, loop_end
+loop_head:
+	sw	zero, 0(t0)
+	beq	t0, t1, loop_end
+	addi	t0, t0, 4
+	j	loop_head
+loop_end:
+	ret
+	nop
+
+_irq_wrapper:
+	add	sp, sp, -16*REGBYTES
+	sw	a0,  1*REGBYTES(sp)
+	sw	a1,  2*REGBYTES(sp)
+	sw	a2,  3*REGBYTES(sp)
+	sw	a3,  4*REGBYTES(sp)
+	sw	a4,  5*REGBYTES(sp)
+	sw	a5,  6*REGBYTES(sp)
+	sw	a6,  7*REGBYTES(sp)
+	sw	a7,  8*REGBYTES(sp)
+	sw	ra,  9*REGBYTES(sp)
+	sw	t0, 10*REGBYTES(sp)
+	sw	t1, 11*REGBYTES(sp)
+	sw	t2, 12*REGBYTES(sp)
+	sw	t3, 13*REGBYTES(sp)
+	sw	t4, 14*REGBYTES(sp)
+	sw	t5, 15*REGBYTES(sp)
+	sw	t6, 16*REGBYTES(sp)
+
+	csrr	a0, mcause
+	jal	isr_handle
+
+	lw	a0,  1*REGBYTES(sp)
+	lw	a1,  2*REGBYTES(sp)
+	lw	a2,  3*REGBYTES(sp)
+	lw	a3,  4*REGBYTES(sp)
+	lw	a4,  5*REGBYTES(sp)
+	lw	a5,  6*REGBYTES(sp)
+	lw	a6,  7*REGBYTES(sp)
+	lw	a7,  8*REGBYTES(sp)
+	lw	ra,  9*REGBYTES(sp)
+	lw	t0, 10*REGBYTES(sp)
+	lw	t1, 11*REGBYTES(sp)
+	lw	t2, 12*REGBYTES(sp)
+	lw	t3, 13*REGBYTES(sp)
+	lw	t4, 14*REGBYTES(sp)
+	lw	t5, 15*REGBYTES(sp)
+	lw	t6, 16*REGBYTES(sp)
+	addi	sp, sp, 16*REGBYTES
+	mret
+
+timer_enable:
+	csrr	a0, mie
+	ori	a0, a0, 0x80
+	csrw	mie, a0
+	ret
+
+timer_disable:
+	csrr	a0, mie
+	xori	a0, a0, 0x80
+	csrw	mie, a0
+	ret
+
+interrupt_enable:
+	csrr	a0, mie
+	li	a1, 0x800
+	or	a0, a0, a1
+	csrw	mie, a0
+	csrr	a0, mstatus
+	ori	a0, a0, 0x8
+	csrw	mstatus, a0
+	ret
+
+interrupt_disable:
+	csrr	a0, mie
+	li	a1, 0x800
+	xor	a0, a0, a1
+	csrw	mie, a0
+	csrr	a0, mstatus
+	xori	a0, a0, 0x8
+	csrw	mstatus, a0
+	ret
+
+# Basic driver for debugging
+
+gpio_set_pin:
+	li	t0, 0xf0000000
+	sw	a0, 0x10(t0)
+	sw	a0, 0x14(t0)
+	ret
+
+uart_putc:
+	li	t0, 0xf0004000
+	sw	a0, 0x18(t0)
+	ret

--- a/software/elemrv_c/gen_coremark_container.sh
+++ b/software/elemrv_c/gen_coremark_container.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 aesc silicon
+#
+# SPDX-License-Identifier: Apache-2.0
+
+FW_DIR=${BUILD_ROOT}/${SOC}/firmware/
+IMG_CONTAINER=${FW_DIR}/coremark_container.img
+
+dd if=/dev/zero of=${IMG_CONTAINER} bs=1k count=512
+dd if=${FW_DIR}/bootrom/kernel.img of=${IMG_CONTAINER} conv=notrunc
+dd if=${FW_DIR}/coremark/kernel.img of=${IMG_CONTAINER} seek=4 bs=1k conv=notrunc
+echo "Generated ${IMG_CONTAINER}"

--- a/software/elemrv_h/coremark/core_portme.c
+++ b/software/elemrv_h/coremark/core_portme.c
@@ -1,0 +1,215 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdarg.h>
+
+#include "coremark.h"
+#include "core_portme.h"
+
+#include "soc.h"
+#include "uart.h"
+#include "mtimer.h"
+
+#if VALIDATION_RUN
+volatile ee_s32 seed1_volatile = 0x3415;
+volatile ee_s32 seed2_volatile = 0x3415;
+volatile ee_s32 seed3_volatile = 0x66;
+#endif
+#if PERFORMANCE_RUN
+volatile ee_s32 seed1_volatile = 0x0;
+volatile ee_s32 seed2_volatile = 0x0;
+volatile ee_s32 seed3_volatile = 0x66;
+#endif
+#if PROFILE_RUN
+volatile ee_s32 seed1_volatile = 0x8;
+volatile ee_s32 seed2_volatile = 0x8;
+volatile ee_s32 seed3_volatile = 0x8;
+#endif
+volatile ee_s32 seed4_volatile = ITERATIONS;
+volatile ee_s32 seed5_volatile = 0;
+
+ee_u32 default_num_contexts = 1;
+
+static struct uart_driver uart;
+static struct mtimer_driver mtimer;
+
+#define EE_TICKS_PER_SEC MTIMERCTRL_FREQ
+
+/* The machine timer is a 64-bit up-counter split into two 32-bit registers.
+ * Re-read the high word to discard a sample taken across a low-word carry.
+ */
+static unsigned long long mtimer_read(void)
+{
+	unsigned int high, low;
+
+	do {
+		high = mtimer.regs->cnt_high;
+		low = mtimer.regs->cnt_low;
+	} while (high != mtimer.regs->cnt_high);
+
+	return ((unsigned long long)high << 32) | low;
+}
+
+static unsigned long long start_time_val, stop_time_val;
+
+void start_time(void)
+{
+	start_time_val = mtimer_read();
+}
+
+void stop_time(void)
+{
+	stop_time_val = mtimer_read();
+}
+
+CORE_TICKS get_time(void)
+{
+	return (CORE_TICKS)(stop_time_val - start_time_val);
+}
+
+secs_ret time_in_secs(CORE_TICKS ticks)
+{
+	return (secs_ret)(ticks / EE_TICKS_PER_SEC);
+}
+
+/* Minimal formatted output over UART0. CoreMark needs %d, %u, %x, %s and the
+ * 'l' length modifier; %f is never reached because HAS_FLOAT is 0.
+ */
+static void ee_putc(char c)
+{
+	if (c == '\n')
+		uart_putc(&uart, '\r');
+	uart_putc(&uart, (unsigned char)c);
+}
+
+static void ee_puts(const char *s)
+{
+	while (*s)
+		ee_putc(*s++);
+}
+
+static void ee_put_unsigned(unsigned long value, unsigned int base,
+			    unsigned int width, char pad)
+{
+	char buffer[32];
+	unsigned int length = 0;
+
+	do {
+		unsigned int digit = (unsigned int)(value % base);
+
+		buffer[length++] = (char)(digit < 10 ? '0' + digit
+						     : 'a' + digit - 10);
+		value /= base;
+	} while (value);
+
+	while (length < width)
+		buffer[length++] = pad;
+
+	while (length)
+		ee_putc(buffer[--length]);
+}
+
+int ee_printf(const char *fmt, ...)
+{
+	va_list args;
+
+	va_start(args, fmt);
+
+	while (*fmt) {
+		unsigned int width = 0;
+		int is_long = 0;
+		char pad = ' ';
+
+		if (*fmt != '%') {
+			ee_putc(*fmt++);
+			continue;
+		}
+		fmt++;
+
+		if (*fmt == '0') {
+			pad = '0';
+			fmt++;
+		}
+		while (*fmt >= '0' && *fmt <= '9')
+			width = width * 10 + (unsigned int)(*fmt++ - '0');
+		while (*fmt == 'l') {
+			is_long = 1;
+			fmt++;
+		}
+
+		switch (*fmt) {
+		case 'd': {
+			long value = is_long ? va_arg(args, long)
+					     : va_arg(args, int);
+
+			if (value < 0) {
+				ee_putc('-');
+				value = -value;
+			}
+			ee_put_unsigned((unsigned long)value, 10, width, pad);
+			break;
+		}
+		case 'u':
+			ee_put_unsigned(is_long ? va_arg(args, unsigned long)
+						: va_arg(args, unsigned int),
+					10, width, pad);
+			break;
+		case 'x':
+			ee_put_unsigned(is_long ? va_arg(args, unsigned long)
+						: va_arg(args, unsigned int),
+					16, width, pad);
+			break;
+		case 'c':
+			ee_putc((char)va_arg(args, int));
+			break;
+		case 's':
+			ee_puts(va_arg(args, const char *));
+			break;
+		case '%':
+			ee_putc('%');
+			break;
+		default:
+			ee_putc('%');
+			ee_putc(*fmt);
+			break;
+		}
+		fmt++;
+	}
+
+	va_end(args);
+
+	return 0;
+}
+
+void portable_init(core_portable *p, int *argc, char *argv[])
+{
+	(void)argc;
+	(void)argv;
+
+	mtimer_init(&mtimer, MTIMERCTRL_BASE);
+	uart_init(&uart, UART0CTRL_BASE,
+		  UART_CALC_FREQUENCY(UART0CTRL_FREQ, UART0CTRL_BAUD, 8));
+
+	if (sizeof(ee_ptr_int) != sizeof(ee_u8 *))
+		ee_printf("ERROR! ee_ptr_int does not hold a pointer!\n");
+	if (sizeof(ee_u32) != 4)
+		ee_printf("ERROR! ee_u32 is not 32 bits!\n");
+
+	p->portable_id = 1;
+}
+
+void portable_fini(core_portable *p)
+{
+	p->portable_id = 0;
+
+	/* time_in_secs() truncates to whole seconds because this port has no
+	 * floating point. Print the raw inputs so the host can recompute
+	 * iterations/sec exactly.
+	 */
+	ee_printf("Timer ticks      : %lu\n",
+		  (long unsigned)(stop_time_val - start_time_val));
+	ee_printf("Timer frequency  : %lu\n", (long unsigned)EE_TICKS_PER_SEC);
+}

--- a/software/elemrv_h/coremark/core_portme.h
+++ b/software/elemrv_h/coremark/core_portme.h
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CORE_PORTME_H
+#define CORE_PORTME_H
+
+/* ElemRV-H is rv32i_zicsr: no F/D extension and no Zicntr, so floating point
+ * is avoided entirely and timing comes from the machine timer instead of
+ * mcycle. portable_fini() prints the raw tick count and the timer frequency so
+ * the score can be recomputed at full precision on the host.
+ */
+#define HAS_FLOAT  0
+#define HAS_TIME_H 0
+#define USE_CLOCK  0
+#define HAS_STDIO  0
+#define HAS_PRINTF 0
+
+#define COMPILER_VERSION "GCC" __VERSION__
+#ifndef COMPILER_FLAGS
+#define COMPILER_FLAGS FLAGS_STR
+#endif
+#define MEM_LOCATION "STACK"
+
+typedef signed short   ee_s16;
+typedef unsigned short ee_u16;
+typedef signed int     ee_s32;
+typedef double         ee_f32;
+typedef unsigned char  ee_u8;
+typedef unsigned int   ee_u32;
+typedef ee_u32         ee_ptr_int;
+typedef unsigned int   ee_size_t;
+#define NULL ((void *)0)
+
+#define align_mem(x) (void *)(4 + (((ee_ptr_int)(x)-1) & ~3))
+
+#define CORETIMETYPE ee_u32
+typedef ee_u32 CORE_TICKS;
+
+#ifndef SEED_METHOD
+#define SEED_METHOD SEED_VOLATILE
+#endif
+
+#ifndef MEM_METHOD
+#define MEM_METHOD MEM_STACK
+#endif
+
+#ifndef MULTITHREAD
+#define MULTITHREAD 1
+#define USE_PTHREAD 0
+#define USE_FORK    0
+#define USE_SOCKET  0
+#endif
+
+/* No argc/argv from start.s, and _kernel() ignores the return value. */
+#define MAIN_HAS_NOARGC   1
+#define MAIN_HAS_NORETURN 0
+
+extern ee_u32 default_num_contexts;
+
+typedef struct CORE_PORTABLE_S
+{
+	ee_u8 portable_id;
+} core_portable;
+
+void portable_init(core_portable *p, int *argc, char *argv[]);
+void portable_fini(core_portable *p);
+
+#if !defined(PROFILE_RUN) && !defined(PERFORMANCE_RUN) \
+	&& !defined(VALIDATION_RUN)
+#if (TOTAL_DATA_SIZE == 1200)
+#define PROFILE_RUN 1
+#elif (TOTAL_DATA_SIZE == 2000)
+#define PERFORMANCE_RUN 1
+#else
+#define VALIDATION_RUN 1
+#endif
+#endif
+
+int ee_printf(const char *fmt, ...);
+
+#endif /* CORE_PORTME_H */

--- a/software/elemrv_h/coremark/kernel.c
+++ b/software/elemrv_h/coremark/kernel.c
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "soc.h"
+#include "uart.h"
+
+extern void hang(void);
+extern int main(void);
+
+/* start.s jumps here once bss is cleared and the stack is set up. Interrupts
+ * stay disabled for the whole run so nothing perturbs the measurement.
+ */
+void _kernel(void)
+{
+	struct uart_driver uart;
+
+	/* Banner before the benchmark starts: CoreMark itself prints nothing
+	 * until the run completes, which takes a while.
+	 */
+	uart_init(&uart, UART0CTRL_BASE,
+		  UART_CALC_FREQUENCY(UART0CTRL_FREQ, UART0CTRL_BAUD, 8));
+	uart_puts(&uart, (unsigned char *)"\r\nCoreMark starting...\r\n");
+
+	main();
+
+	hang();
+}
+
+/* Referenced by _irq_wrapper in start.s. Unreachable while interrupts are
+ * disabled, but the symbol is needed because the link uses --no-undefined.
+ */
+void isr_handle(unsigned int mcause)
+{
+	(void)mcause;
+}

--- a/software/elemrv_h/coremark/kernel.ld
+++ b/software/elemrv_h/coremark/kernel.ld
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Specify the memory areas */
+
+MEMORY
+{
+	OCRAM (xrw): ORIGIN = 0x80000000, LENGTH = 8k
+	FLASH (xr ): ORIGIN = 0xA0001000, LENGTH = 512k
+}
+stack_size = 8k;
+heap_size = 0;
+
+/* define beginning and ending of stack */
+__stack_start = ORIGIN(OCRAM) + LENGTH(OCRAM);
+__stack_end = __stack_start - stack_size;
+
+ENTRY(_head)
+
+SECTIONS {
+	.text : {
+		 KEEP(*(.text.head))
+		*(.text .text.*)
+	} > FLASH
+
+	.irs_handler : {
+		*(.irs_handler)
+	} > FLASH
+
+	.rodata : {
+		*(.rodata .rodata.*)
+		*(.srodata .srodata.*)
+	} > FLASH
+
+	.data : {
+		. = ALIGN(4);
+		__data_start = . ;
+		*(.data .data.*)
+		*(.sdata .sdata.*)
+		. = ALIGN(4);
+		__data_end = . ;
+	} > OCRAM AT> FLASH
+	__data_load = LOADADDR(.data);
+
+	.bss (NOLOAD) : {
+		__bss_start = . ;
+		*(.bss .bss.*)
+		*(COMMON)
+		*(.sbss .sbss.*)
+		__bss_end = . ;
+	} > OCRAM
+}

--- a/software/elemrv_h/coremark/start.s
+++ b/software/elemrv_h/coremark/start.s
@@ -1,0 +1,146 @@
+/*
+ * SPDX-FileCopyrightText: 2025 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+.equ REGBYTES, 0x4
+
+.section .text
+.global hang
+.global init_trap
+.global interrupt_enable
+.global interrupt_disable
+.extern isr_handle
+.global _head
+_head:
+	li	a0, 1
+	jal	gpio_set_pin
+
+	jal	_init_data
+	jal	_init_bss
+
+	la	sp, __stack_start
+	j	_kernel
+
+hang:
+	nop
+	beqz	zero, hang
+
+init_trap:
+	la	t0, _irq_wrapper
+	csrw	mtvec, t0
+	ret
+
+_init_data:
+	la	t0, __data_load
+	la	t1, __data_start
+	la	t2, __data_end
+	beq	t1, t2, data_end
+data_head:
+	lw	t3, 0(t0)
+	sw	t3, 0(t1)
+	addi	t0, t0, 4
+	addi	t1, t1, 4
+	bltu	t1, t2, data_head
+data_end:
+	ret
+
+_init_bss:
+	la	t0, __bss_start
+	la	t1, __bss_end
+	beq	t0, t1, loop_end
+loop_head:
+	sw	zero, 0(t0)
+	beq	t0, t1, loop_end
+	addi	t0, t0, 4
+	j	loop_head
+loop_end:
+	ret
+	nop
+
+_irq_wrapper:
+	add	sp, sp, -16*REGBYTES
+	sw	a0,  1*REGBYTES(sp)
+	sw	a1,  2*REGBYTES(sp)
+	sw	a2,  3*REGBYTES(sp)
+	sw	a3,  4*REGBYTES(sp)
+	sw	a4,  5*REGBYTES(sp)
+	sw	a5,  6*REGBYTES(sp)
+	sw	a6,  7*REGBYTES(sp)
+	sw	a7,  8*REGBYTES(sp)
+	sw	ra,  9*REGBYTES(sp)
+	sw	t0, 10*REGBYTES(sp)
+	sw	t1, 11*REGBYTES(sp)
+	sw	t2, 12*REGBYTES(sp)
+	sw	t3, 13*REGBYTES(sp)
+	sw	t4, 14*REGBYTES(sp)
+	sw	t5, 15*REGBYTES(sp)
+	sw	t6, 16*REGBYTES(sp)
+
+	csrr	a0, mcause
+	jal	isr_handle
+
+	lw	a0,  1*REGBYTES(sp)
+	lw	a1,  2*REGBYTES(sp)
+	lw	a2,  3*REGBYTES(sp)
+	lw	a3,  4*REGBYTES(sp)
+	lw	a4,  5*REGBYTES(sp)
+	lw	a5,  6*REGBYTES(sp)
+	lw	a6,  7*REGBYTES(sp)
+	lw	a7,  8*REGBYTES(sp)
+	lw	ra,  9*REGBYTES(sp)
+	lw	t0, 10*REGBYTES(sp)
+	lw	t1, 11*REGBYTES(sp)
+	lw	t2, 12*REGBYTES(sp)
+	lw	t3, 13*REGBYTES(sp)
+	lw	t4, 14*REGBYTES(sp)
+	lw	t5, 15*REGBYTES(sp)
+	lw	t6, 16*REGBYTES(sp)
+	addi	sp, sp, 16*REGBYTES
+	mret
+
+timer_enable:
+	csrr	a0, mie
+	ori	a0, a0, 0x80
+	csrw	mie, a0
+	ret
+
+timer_disable:
+	csrr	a0, mie
+	xori	a0, a0, 0x80
+	csrw	mie, a0
+	ret
+
+interrupt_enable:
+	csrr	a0, mie
+	li	a1, 0x800
+	or	a0, a0, a1
+	csrw	mie, a0
+	csrr	a0, mstatus
+	ori	a0, a0, 0x8
+	csrw	mstatus, a0
+	ret
+
+interrupt_disable:
+	csrr	a0, mie
+	li	a1, 0x800
+	xor	a0, a0, a1
+	csrw	mie, a0
+	csrr	a0, mstatus
+	xori	a0, a0, 0x8
+	csrw	mstatus, a0
+	ret
+
+# Basic driver for debugging
+
+gpio_set_pin:
+	li	t0, 0xf0000000
+	sw	a0, 0x10(t0)
+	sw	a0, 0x14(t0)
+	ret
+
+uart_putc:
+	li	t0, 0xf0004000
+	sw	a0, 0x18(t0)
+	ret

--- a/software/elemrv_h/gen_coremark_container.sh
+++ b/software/elemrv_h/gen_coremark_container.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 aesc silicon
+#
+# SPDX-License-Identifier: Apache-2.0
+
+FW_DIR=${BUILD_ROOT}/${SOC}/firmware/
+IMG_CONTAINER=${FW_DIR}/coremark_container.img
+
+dd if=/dev/zero of=${IMG_CONTAINER} bs=1k count=512
+dd if=${FW_DIR}/bootrom/kernel.img of=${IMG_CONTAINER} conv=notrunc
+dd if=${FW_DIR}/coremark/kernel.img of=${IMG_CONTAINER} seek=4 bs=1k conv=notrunc
+echo "Generated ${IMG_CONTAINER}"

--- a/software/elemrv_n/coremark/core_portme.c
+++ b/software/elemrv_n/coremark/core_portme.c
@@ -1,0 +1,239 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdarg.h>
+
+#include "coremark.h"
+#include "core_portme.h"
+
+#include "soc.h"
+#include "uart.h"
+#include "mtimer.h"
+
+#if VALIDATION_RUN
+volatile ee_s32 seed1_volatile = 0x3415;
+volatile ee_s32 seed2_volatile = 0x3415;
+volatile ee_s32 seed3_volatile = 0x66;
+#endif
+#if PERFORMANCE_RUN
+volatile ee_s32 seed1_volatile = 0x0;
+volatile ee_s32 seed2_volatile = 0x0;
+volatile ee_s32 seed3_volatile = 0x66;
+#endif
+#if PROFILE_RUN
+volatile ee_s32 seed1_volatile = 0x8;
+volatile ee_s32 seed2_volatile = 0x8;
+volatile ee_s32 seed3_volatile = 0x8;
+#endif
+volatile ee_s32 seed4_volatile = ITERATIONS;
+volatile ee_s32 seed5_volatile = 0;
+
+ee_u32 default_num_contexts = 1;
+
+static struct uart_driver uart;
+static struct mtimer_driver mtimer;
+
+#define EE_TICKS_PER_SEC MTIMERCTRL_FREQ
+
+/* Zicntr/Zihpm are present on this platform, so mcycle and minstret give the
+ * cycle count and IPC alongside the wall-clock measurement.
+ */
+#define READ_CSR64(name)                                                       \
+	({                                                                     \
+		unsigned int hi, lo, hi2;                                      \
+		do {                                                           \
+			__asm__ volatile("csrr %0, " #name "h" : "=r"(hi));     \
+			__asm__ volatile("csrr %0, " #name : "=r"(lo));        \
+			__asm__ volatile("csrr %0, " #name "h" : "=r"(hi2));    \
+		} while (hi != hi2);                                           \
+		((unsigned long long)hi << 32) | lo;                           \
+	})
+
+/* The machine timer is a 64-bit up-counter split into two 32-bit registers.
+ * Re-read the high word to discard a sample taken across a low-word carry.
+ */
+static unsigned long long mtimer_read(void)
+{
+	unsigned int high, low;
+
+	do {
+		high = mtimer.regs->cnt_high;
+		low = mtimer.regs->cnt_low;
+	} while (high != mtimer.regs->cnt_high);
+
+	return ((unsigned long long)high << 32) | low;
+}
+
+static unsigned long long start_time_val, stop_time_val;
+static unsigned long long start_cycles, stop_cycles;
+static unsigned long long start_instret, stop_instret;
+
+void start_time(void)
+{
+	start_instret = READ_CSR64(minstret);
+	start_cycles = READ_CSR64(mcycle);
+	start_time_val = mtimer_read();
+}
+
+void stop_time(void)
+{
+	stop_time_val = mtimer_read();
+	stop_cycles = READ_CSR64(mcycle);
+	stop_instret = READ_CSR64(minstret);
+}
+
+CORE_TICKS get_time(void)
+{
+	return (CORE_TICKS)(stop_time_val - start_time_val);
+}
+
+secs_ret time_in_secs(CORE_TICKS ticks)
+{
+	return (secs_ret)(ticks / EE_TICKS_PER_SEC);
+}
+
+/* Minimal formatted output over UART0. CoreMark needs %d, %u, %x, %s and the
+ * 'l' length modifier; %f is never reached because HAS_FLOAT is 0.
+ */
+static void ee_putc(char c)
+{
+	if (c == '\n')
+		uart_putc(&uart, '\r');
+	uart_putc(&uart, (unsigned char)c);
+}
+
+static void ee_puts(const char *s)
+{
+	while (*s)
+		ee_putc(*s++);
+}
+
+static void ee_put_unsigned(unsigned long value, unsigned int base,
+			    unsigned int width, char pad)
+{
+	char buffer[32];
+	unsigned int length = 0;
+
+	do {
+		unsigned int digit = (unsigned int)(value % base);
+
+		buffer[length++] = (char)(digit < 10 ? '0' + digit
+						     : 'a' + digit - 10);
+		value /= base;
+	} while (value);
+
+	while (length < width)
+		buffer[length++] = pad;
+
+	while (length)
+		ee_putc(buffer[--length]);
+}
+
+int ee_printf(const char *fmt, ...)
+{
+	va_list args;
+
+	va_start(args, fmt);
+
+	while (*fmt) {
+		unsigned int width = 0;
+		int is_long = 0;
+		char pad = ' ';
+
+		if (*fmt != '%') {
+			ee_putc(*fmt++);
+			continue;
+		}
+		fmt++;
+
+		if (*fmt == '0') {
+			pad = '0';
+			fmt++;
+		}
+		while (*fmt >= '0' && *fmt <= '9')
+			width = width * 10 + (unsigned int)(*fmt++ - '0');
+		while (*fmt == 'l') {
+			is_long = 1;
+			fmt++;
+		}
+
+		switch (*fmt) {
+		case 'd': {
+			long value = is_long ? va_arg(args, long)
+					     : va_arg(args, int);
+
+			if (value < 0) {
+				ee_putc('-');
+				value = -value;
+			}
+			ee_put_unsigned((unsigned long)value, 10, width, pad);
+			break;
+		}
+		case 'u':
+			ee_put_unsigned(is_long ? va_arg(args, unsigned long)
+						: va_arg(args, unsigned int),
+					10, width, pad);
+			break;
+		case 'x':
+			ee_put_unsigned(is_long ? va_arg(args, unsigned long)
+						: va_arg(args, unsigned int),
+					16, width, pad);
+			break;
+		case 'c':
+			ee_putc((char)va_arg(args, int));
+			break;
+		case 's':
+			ee_puts(va_arg(args, const char *));
+			break;
+		case '%':
+			ee_putc('%');
+			break;
+		default:
+			ee_putc('%');
+			ee_putc(*fmt);
+			break;
+		}
+		fmt++;
+	}
+
+	va_end(args);
+
+	return 0;
+}
+
+void portable_init(core_portable *p, int *argc, char *argv[])
+{
+	(void)argc;
+	(void)argv;
+
+	mtimer_init(&mtimer, MTIMERCTRL_BASE);
+	uart_init(&uart, UART0CTRL_BASE,
+		  UART_CALC_FREQUENCY(UART0CTRL_FREQ, UART0CTRL_BAUD, 8));
+
+	if (sizeof(ee_ptr_int) != sizeof(ee_u8 *))
+		ee_printf("ERROR! ee_ptr_int does not hold a pointer!\n");
+	if (sizeof(ee_u32) != 4)
+		ee_printf("ERROR! ee_u32 is not 32 bits!\n");
+
+	p->portable_id = 1;
+}
+
+void portable_fini(core_portable *p)
+{
+	p->portable_id = 0;
+
+	/* time_in_secs() truncates to whole seconds because this port has no
+	 * floating point. Print the raw inputs so the host can recompute
+	 * iterations/sec exactly.
+	 */
+	ee_printf("Timer ticks      : %lu\n",
+		  (long unsigned)(stop_time_val - start_time_val));
+	ee_printf("Timer frequency  : %lu\n", (long unsigned)EE_TICKS_PER_SEC);
+	ee_printf("CPU cycles       : %lu\n",
+		  (long unsigned)(stop_cycles - start_cycles));
+	ee_printf("Instructions     : %lu\n",
+		  (long unsigned)(stop_instret - start_instret));
+}

--- a/software/elemrv_n/coremark/core_portme.h
+++ b/software/elemrv_n/coremark/core_portme.h
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CORE_PORTME_H
+#define CORE_PORTME_H
+
+/* ElemRV-H is rv32i_zicsr: no F/D extension and no Zicntr, so floating point
+ * is avoided entirely and timing comes from the machine timer instead of
+ * mcycle. portable_fini() prints the raw tick count and the timer frequency so
+ * the score can be recomputed at full precision on the host.
+ */
+#define HAS_FLOAT  0
+#define HAS_TIME_H 0
+#define USE_CLOCK  0
+#define HAS_STDIO  0
+#define HAS_PRINTF 0
+
+#define COMPILER_VERSION "GCC" __VERSION__
+#ifndef COMPILER_FLAGS
+#define COMPILER_FLAGS FLAGS_STR
+#endif
+#define MEM_LOCATION "STACK"
+
+typedef signed short   ee_s16;
+typedef unsigned short ee_u16;
+typedef signed int     ee_s32;
+typedef double         ee_f32;
+typedef unsigned char  ee_u8;
+typedef unsigned int   ee_u32;
+typedef ee_u32         ee_ptr_int;
+typedef unsigned int   ee_size_t;
+#define NULL ((void *)0)
+
+#define align_mem(x) (void *)(4 + (((ee_ptr_int)(x)-1) & ~3))
+
+#define CORETIMETYPE ee_u32
+typedef ee_u32 CORE_TICKS;
+
+#ifndef SEED_METHOD
+#define SEED_METHOD SEED_VOLATILE
+#endif
+
+#ifndef MEM_METHOD
+#define MEM_METHOD MEM_STACK
+#endif
+
+#ifndef MULTITHREAD
+#define MULTITHREAD 1
+#define USE_PTHREAD 0
+#define USE_FORK    0
+#define USE_SOCKET  0
+#endif
+
+/* No argc/argv from start.s, and _kernel() ignores the return value. */
+#define MAIN_HAS_NOARGC   1
+#define MAIN_HAS_NORETURN 0
+
+extern ee_u32 default_num_contexts;
+
+typedef struct CORE_PORTABLE_S
+{
+	ee_u8 portable_id;
+} core_portable;
+
+void portable_init(core_portable *p, int *argc, char *argv[]);
+void portable_fini(core_portable *p);
+
+#if !defined(PROFILE_RUN) && !defined(PERFORMANCE_RUN) \
+	&& !defined(VALIDATION_RUN)
+#if (TOTAL_DATA_SIZE == 1200)
+#define PROFILE_RUN 1
+#elif (TOTAL_DATA_SIZE == 2000)
+#define PERFORMANCE_RUN 1
+#else
+#define VALIDATION_RUN 1
+#endif
+#endif
+
+int ee_printf(const char *fmt, ...);
+
+#endif /* CORE_PORTME_H */

--- a/software/elemrv_n/coremark/kernel.c
+++ b/software/elemrv_n/coremark/kernel.c
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "soc.h"
+#include "uart.h"
+
+extern void hang(void);
+extern int main(void);
+
+/* start.s jumps here once bss is cleared and the stack is set up. Interrupts
+ * stay disabled for the whole run so nothing perturbs the measurement.
+ */
+void _kernel(void)
+{
+	struct uart_driver uart;
+
+	/* Banner before the benchmark starts: CoreMark itself prints nothing
+	 * until the run completes, which takes a while.
+	 */
+	uart_init(&uart, UART0CTRL_BASE,
+		  UART_CALC_FREQUENCY(UART0CTRL_FREQ, UART0CTRL_BAUD, 8));
+	uart_puts(&uart, (unsigned char *)"\r\nCoreMark starting...\r\n");
+
+	main();
+
+	hang();
+}
+
+/* Referenced by _irq_wrapper in start.s. Unreachable while interrupts are
+ * disabled, but the symbol is needed because the link uses --no-undefined.
+ */
+void isr_handle(unsigned int mcause)
+{
+	(void)mcause;
+}

--- a/software/elemrv_n/coremark/kernel.ld
+++ b/software/elemrv_n/coremark/kernel.ld
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: 2025 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Specify the memory areas */
+
+MEMORY
+{
+	OCRAM (xrw): ORIGIN = 0x80000000, LENGTH = 8k
+	MEM   (xrw): ORIGIN = 0x90000000, LENGTH = 64k
+	FLASH (xr ): ORIGIN = 0xA0001000, LENGTH = 64k
+}
+stack_size = 8k;
+heap_size = 0;
+
+/* define beginning and ending of stack */
+__stack_start = ORIGIN(MEM) + LENGTH(MEM);
+__stack_end = __stack_start - stack_size;
+
+ENTRY(_head)
+
+SECTIONS {
+	.text : {
+		 KEEP(*(.text.head))
+		*(.text .text.*)
+	} > MEM
+
+	.irs_handler : {
+		*(.irs_handler)
+	} > MEM
+
+	.rodata : {
+		*(.rodata .rodata.*)
+		*(.srodata .srodata.*)
+	} > MEM
+
+	.data : {
+		. = ALIGN(4);
+		*(.data .data.*)
+		*(.sdata .sdata.*)
+		. = ALIGN(4);
+	} > MEM
+
+	.bss (NOLOAD) : {
+		__bss_start = . ;
+		*(.bss .bss.*)
+		*(COMMON)
+		*(.sbss .sbss.*)
+		__bss_end = . ;
+	} > MEM
+}

--- a/software/elemrv_n/coremark/start.s
+++ b/software/elemrv_n/coremark/start.s
@@ -1,0 +1,131 @@
+/*
+ * SPDX-FileCopyrightText: 2025 aesc silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+.equ REGBYTES, 0x4
+
+.section .text
+.global hang
+.global init_trap
+.global interrupt_enable
+.global interrupt_disable
+.extern isr_handle
+.global _head
+_head:
+	li	a0, 1
+	jal	gpio_set_pin
+
+	jal	_init_bss
+
+	la	sp, __stack_start
+	j	_kernel
+
+hang:
+	nop
+	beqz	zero, hang
+
+init_trap:
+	la	t0, _irq_wrapper
+	csrw	mtvec, t0
+	ret
+
+_init_bss:
+	la	t0, __bss_start
+	la	t1, __bss_end
+	beq	t0, t1, loop_end
+loop_head:
+	sw	zero, 0(t0)
+	beq	t0, t1, loop_end
+	addi	t0, t0, 4
+	j	loop_head
+loop_end:
+	ret
+	nop
+
+_irq_wrapper:
+	add	sp, sp, -16*REGBYTES
+	sw	a0,  1*REGBYTES(sp)
+	sw	a1,  2*REGBYTES(sp)
+	sw	a2,  3*REGBYTES(sp)
+	sw	a3,  4*REGBYTES(sp)
+	sw	a4,  5*REGBYTES(sp)
+	sw	a5,  6*REGBYTES(sp)
+	sw	a6,  7*REGBYTES(sp)
+	sw	a7,  8*REGBYTES(sp)
+	sw	ra,  9*REGBYTES(sp)
+	sw	t0, 10*REGBYTES(sp)
+	sw	t1, 11*REGBYTES(sp)
+	sw	t2, 12*REGBYTES(sp)
+	sw	t3, 13*REGBYTES(sp)
+	sw	t4, 14*REGBYTES(sp)
+	sw	t5, 15*REGBYTES(sp)
+	sw	t6, 16*REGBYTES(sp)
+
+	csrr	a0, mcause
+	jal	isr_handle
+
+	lw	a0,  1*REGBYTES(sp)
+	lw	a1,  2*REGBYTES(sp)
+	lw	a2,  3*REGBYTES(sp)
+	lw	a3,  4*REGBYTES(sp)
+	lw	a4,  5*REGBYTES(sp)
+	lw	a5,  6*REGBYTES(sp)
+	lw	a6,  7*REGBYTES(sp)
+	lw	a7,  8*REGBYTES(sp)
+	lw	ra,  9*REGBYTES(sp)
+	lw	t0, 10*REGBYTES(sp)
+	lw	t1, 11*REGBYTES(sp)
+	lw	t2, 12*REGBYTES(sp)
+	lw	t3, 13*REGBYTES(sp)
+	lw	t4, 14*REGBYTES(sp)
+	lw	t5, 15*REGBYTES(sp)
+	lw	t6, 16*REGBYTES(sp)
+	addi	sp, sp, 16*REGBYTES
+	mret
+
+timer_enable:
+	csrr	a0, mie
+	ori	a0, a0, 0x80
+	csrw	mie, a0
+	ret
+
+timer_disable:
+	csrr	a0, mie
+	xori	a0, a0, 0x80
+	csrw	mie, a0
+	ret
+
+interrupt_enable:
+	csrr	a0, mie
+	li	a1, 0x800
+	or	a0, a0, a1
+	csrw	mie, a0
+	csrr	a0, mstatus
+	ori	a0, a0, 0x8
+	csrw	mstatus, a0
+	ret
+
+interrupt_disable:
+	csrr	a0, mie
+	li	a1, 0x800
+	xor	a0, a0, a1
+	csrw	mie, a0
+	csrr	a0, mstatus
+	xori	a0, a0, 0x8
+	csrw	mstatus, a0
+	ret
+
+# Basic driver for debugging
+
+gpio_set_pin:
+	li	t0, 0xf0000000
+	sw	a0, 0x10(t0)
+	sw	a0, 0x14(t0)
+	ret
+
+uart_putc:
+	li	t0, 0xf0006000
+	sw	a0, 0x18(t0)
+	ret

--- a/software/elemrv_n/gen_coremark_container.sh
+++ b/software/elemrv_n/gen_coremark_container.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 aesc silicon
+#
+# SPDX-License-Identifier: Apache-2.0
+
+FW_DIR=${BUILD_ROOT}/${SOC}/firmware/
+IMG_CONTAINER=${FW_DIR}/coremark_container.img
+
+dd if=/dev/zero of=${IMG_CONTAINER} bs=1k count=512
+dd if=${FW_DIR}/bootrom/kernel.img of=${IMG_CONTAINER} conv=notrunc
+dd if=${FW_DIR}/coremark/kernel.img of=${IMG_CONTAINER} seek=4 bs=1k conv=notrunc
+echo "Generated ${IMG_CONTAINER}"


### PR DESCRIPTION
 Adds CoreMark as a benchmark target for all three SoCs, publishes the resulting numbers, and fixes the on-chip RAM path that prevented executing code from OCRAM.

  **CoreMark**

  Adds CoreMark to the manifest and a bare-metal port per SoC under software/elemrv_{h,c,n}/coremark/: the porting layer, linker script, startup and container script. The five benchmark sources are compiled in
  place from the pinned checkout and never modified. A dedicated Taskfile.coremark.yml drives the build, and soc.h generation is extended to the coremark firmware.

  The ports have no floating point, since none of these cores has an FPU, so portable_fini() also prints the raw tick count and timer frequency. CoreMark's own Iterations/Sec line is computed from a truncated
  whole-second time and misreports the result; the documented figures are derived from the raw values.

  ElemRV-N additionally reports mcycle and minstret, giving cycles per iteration and IPC.

  **Documentation**

  docs: nonmetals: Add Performance Chapter adds a CoreMark table with platforms as rows so it grows downward as tiers are added:

```
              | CoreMark/MHz | Iterations/s | Clock  | ISA                        | Executed from
  ------------+--------------+--------------+--------+----------------------------+---------------
   Hydrogen   |        0.005 |         0.24 | 50 MHz | rv32i_zicsr                | XIP flash
   Carbon     |        1.590 |        79.48 | 50 MHz | rv32imc_zicsr              | XIP flash
   Nitrogen   |        2.360 |        70.80 | 30 MHz | rv32imc_zicsr_zicntr_zihpm | HyperRAM
   ```

  The accompanying prose explains that the spread is memory and ISA rather than pipeline — Hydrogen has no instruction cache and no hardware multiply, so every fetch is a SPI transaction and every multiply a
  libgcc call. Nitrogen's 1.48x over Carbon reflects what the data cache and branch prediction add once the core is no longer starved for instructions.

  **On-chip RAM**

  Switch to TileLinkOnChipRam replaces TileLinkIhpOnChipRam in all three SoCs, on both FPGA and ASIC targets. The dedicated IP serves exactly one D-beat per request, so an instruction-cache line fill from OCRAM
  never completes and hangs the hart — which is why ElemRV-C and ElemRV-N could not execute code from internal RAM. SpinalHDL's memory blackboxer maps the generic Mem onto the IHP SRAM macros, so the ASIC
  targets keep their hard macro and floorplan placement.

  Taskfile: Add zifencei to ARCH adds the extension to the compiler flags, since the VexiiRiscv configurations enable it.

  **Cleanups**

  Renode .resc paths updated for Nafarr's new location, along with the docs workflows and CONTRIBUTING.md; issue-template multi-line strings fixed; an unused CRC32 import removed from ElemRV-C.

Fixes #44
Closes #31 