### PR TITLE
Fix PDK_ROOT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ script:
 
   # TODO Full RTL to GDS flow takes too long for travis
   # Generate layout
-  #- CI=true IS_HEADLESS=true task SOC=ElemRV-H TARGET=SG13CMOS5L asic:build
+  - CI=true IS_HEADLESS=true task SOC=ElemRV-H TARGET=SG13CMOS5L asic:build stage=floorplan
 
   # Add metal fill
   #- CI=true IS_HEADLESS=true task SOC=ElemRV-H TARGET=SG13CMOS5L asic:fill

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -124,7 +124,8 @@ env:
   FPGA_PACKAGE: CABGA554
   FPGA_FREQUENCY: 50
   OPENFPGALOADER_BOARD: ecpix5_r03
-  PDK_ROOT: "{{.PWD}}/pdks"
+  # TODO CMOS5L is not yet supported in Ciel
+  PDK_ROOT: "{{.PWD}}/pdks/IHP-Open-PDK"
   ZIBAL_BASE: "{{.PWD}}/modules/elements/zibal"
   NAFARR_BASE: "{{.ZIBAL_BASE}}/ext/nafarr"
   COREMARK_BASE: "{{.PWD}}/tools/coremark"

--- a/manifest-nightly.xml
+++ b/manifest-nightly.xml
@@ -15,5 +15,5 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 	<project name="aesc-silicon/OpenROAD-flow-scripts" path="tools/OpenROAD-flow-scripts" revision="0bcb5dd40908d0313168372454caffc81d6f9b6f" />
 	<project name="antmicro/renode-verilator-integration" path="tools/renode-verilator-integration" revision="c9692ca32c8c160e0c268bd0f5207359cee1626d" />
 	<project name="eembc/coremark" path="tools/coremark" revision="1f483d5b8316753a742cbf5590caf5bd0a4e4777" />
-	<project name="aesc-silicon/IHP-Open-PDK" sync-s="true" path="pdks/IHP-Open-PDK" revision="16f0fd4b8dd36c694583cfe61d0ecdaf61015c7f" />
+	<project name="aesc-silicon/IHP-Open-PDK" sync-s="true" path="pdks/IHP-Open-PDK" revision="9a4362d14a7666b82e6a2031131bc5bbe6d50b9a" />
 </manifest>

--- a/manifest.xml
+++ b/manifest.xml
@@ -15,5 +15,5 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 	<project name="aesc-silicon/OpenROAD-flow-scripts" path="tools/OpenROAD-flow-scripts" revision="0bcb5dd40908d0313168372454caffc81d6f9b6f" />
 	<project name="antmicro/renode-verilator-integration" path="tools/renode-verilator-integration" revision="c9692ca32c8c160e0c268bd0f5207359cee1626d" />
 	<project name="eembc/coremark" path="tools/coremark" revision="1f483d5b8316753a742cbf5590caf5bd0a4e4777" />
-	<project name="aesc-silicon/IHP-Open-PDK" sync-s="true" path="pdks/IHP-Open-PDK" revision="6e8e108025798bef4a150f8692e2fd9a0bafd87b" />
+	<project name="aesc-silicon/IHP-Open-PDK" sync-s="true" path="pdks/IHP-Open-PDK" revision="9a4362d14a7666b82e6a2031131bc5bbe6d50b9a" />
 </manifest>


### PR DESCRIPTION
SG13CMOS5L is not yet available as PDK in Ciel. Change the PDK_ROOT to pdks/IHP-Open-PDK in the meanwhile to unlock the CMOS5L PDK.